### PR TITLE
Add a disable for string ids, whitespace cleanup

### DIFF
--- a/tap_asana/asana.py
+++ b/tap_asana/asana.py
@@ -15,8 +15,8 @@ class Asana(object):
     self.refresh_token = refresh_token
     self.access_token = access_token
     self._client = self._oauth_auth() or self._access_token_auth()
+    self._client.headers={'asana-disable': 'string_ids'}
     self.refresh_access_token()
-
 
   def _oauth_auth(self):
     if self.client_id is None or self.client_secret is None or self.redirect_uri is None or self.refresh_token is None:
@@ -24,19 +24,16 @@ class Asana(object):
       return None
     return asana.Client.oauth(client_id=self.client_id, client_secret=self.client_secret, redirect_uri=self.redirect_uri)
 
-
   def _access_token_auth(self):
     if self.access_token is None:
       LOGGER.debug("OAuth authentication unavailable.")
       return None
     return asana.Client.access_token(self.access_token)
 
-
   def refresh_access_token(self):
     if self._client.session.authorized:
       return
     return self._client.session.refresh_token(self._client.session.token_url, client_id=self.client_id, client_secret=self.client_secret, refresh_token=self.refresh_token)
-
 
   @property
   def client(self):


### PR DESCRIPTION
# Description of change
https://asana.com/developers/news/a-reminder-about-integer-id-deprecation

>  The fastest way to fix your application is to send a HTTP header on all requests: Asana-Disable: string_ids which will disable the behavior that only provides strings

# Manual QA steps
 -  Manually ran the tap:
   - It fails without this change, and runs with it
 
# Risks
 - Low, the tap is currently broken
 
# Rollback steps
 - revert this branch
