### PR TITLE
bump version to 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+ * Releasing from Beta --> GA
+

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-asana",
-    version="0.0.2",
+    version="1.0.0",
     description="Singer.io tap for extracting Asana data",
     author="Stitch",
     url="http://github.com/singer-io/tap-asana",


### PR DESCRIPTION
# Description of change
GA release of tap-asana -- bump the version to 1.0.0

# Manual QA steps
 - n/a
 
# Risks
 - n/a
 
# Rollback steps
 - revert this branch
