### PR TITLE
Workaround for Integer ID Deprecation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,8 @@ setup(
         'dev': [
             'pylint',
             'ipdb',
-            'requests==2.20.0'
+            'requests==2.20.0',
+            'nose'
         ]
     },
     entry_points="""

--- a/tap_asana/schemas/projects.json
+++ b/tap_asana/schemas/projects.json
@@ -13,7 +13,8 @@
     "id": {
       "type": [
         "null",
-        "integer"
+        "integer",
+        "string"
       ]
     },
     "gid": {
@@ -31,7 +32,8 @@
         "id": {
           "type": [
             "null",
-            "integer"
+            "integer",
+            "string"
           ]
         },
         "gid": {
@@ -101,7 +103,8 @@
           "id": {
             "type": [
               "null",
-              "integer"
+              "integer",
+              "string"
             ]
           },
           "gid": {
@@ -133,7 +136,8 @@
           "id": {
             "type": [
               "null",
-              "integer"
+              "integer",
+              "string"
             ]
           },
           "gid": {
@@ -172,7 +176,8 @@
         "id": {
           "type": [
             "null",
-            "integer"
+            "integer",
+            "string"
           ]
         },
         "gid": {
@@ -198,7 +203,8 @@
         "id": {
           "type": [
             "null",
-            "integer"
+            "integer",
+            "string"
           ]
         },
         "gid": {

--- a/tap_asana/schemas/tags.json
+++ b/tap_asana/schemas/tags.json
@@ -7,7 +7,8 @@
     "id": {
       "type": [
         "null",
-        "integer"
+        "integer",
+        "string"
       ]
     },
     "created_at": {
@@ -31,7 +32,8 @@
           "id": {
             "type": [
               "null",
-              "integer"
+              "integer",
+              "string"
             ]
           },
           "gid": {
@@ -76,7 +78,8 @@
         "id": {
           "type": [
             "null",
-            "integer"
+            "integer",
+            "string"
           ]
         },
         "gid": {

--- a/tap_asana/schemas/tasks.json
+++ b/tap_asana/schemas/tasks.json
@@ -7,7 +7,8 @@
     "id": {
       "type": [
         "null",
-        "integer"
+        "integer",
+        "string"
       ]
     },
     "gid": {
@@ -25,7 +26,8 @@
         "id": {
           "type": [
             "null",
-            "integer"
+            "integer",
+            "string"
           ]
         },
         "gid": {
@@ -102,7 +104,8 @@
           "id": {
             "type": [
               "null",
-              "integer"
+              "integer",
+              "string"
             ]
           },
           "gid": {
@@ -171,7 +174,8 @@
           "id": {
             "type": [
               "null",
-              "integer"
+              "integer",
+              "string"
             ]
           },
           "gid": {
@@ -204,7 +208,8 @@
         "id": {
           "type": [
             "null",
-            "integer"
+            "integer",
+            "string"
           ]
         },
         "gid": {
@@ -240,7 +245,8 @@
           "id": {
             "type": [
               "null",
-              "integer"
+              "integer",
+              "string"
             ]
           },
           "gid": {
@@ -272,7 +278,8 @@
           "id": {
             "type": [
               "null",
-              "integer"
+              "integer",
+              "string"
             ]
           },
           "gid": {
@@ -319,7 +326,8 @@
                 "id": {
                   "type": [
                     "null",
-                    "integer"
+                    "integer",
+                    "string"
                   ]
                 },
                 "gid": {
@@ -365,7 +373,8 @@
               "id": {
                 "type": [
                   "null",
-                  "integer"
+                  "integer",
+                  "string"
                 ]
               },
               "gid": {

--- a/tap_asana/schemas/users.json
+++ b/tap_asana/schemas/users.json
@@ -7,7 +7,8 @@
     "id": {
       "type": [
         "null",
-        "integer"
+        "integer",
+        "string"
       ]
     },
     "name": {
@@ -80,7 +81,8 @@
           "id": {
             "type": [
               "null",
-              "integer"
+              "integer",
+              "string"
             ]
           },
           "gid": {

--- a/tap_asana/schemas/workspaces.json
+++ b/tap_asana/schemas/workspaces.json
@@ -7,7 +7,8 @@
     "id": {
       "type": [
         "null",
-        "integer"
+        "integer",
+        "string"
       ]
     },
     "gid": {

--- a/tap_asana/streams/base.py
+++ b/tap_asana/streams/base.py
@@ -151,12 +151,19 @@ class Stream():
             return fn.find_all(**query_params)
         return fn.find_all()
 
+    def _safe_int_convert(self, obj, key):
+        try:
+            return int(obj[key])
+        except:
+            return obj[key]
+
     def _patch_ids(self, obj):
         # NB: Asana has moved to a string 'gid' in place of the existing int 'id'
         # - This is a workaround to keep the existing functionality
         # More Info: https://forum.asana.com/t/reminder-about-two-big-upcoming-api-changes-string-ids-and-new-sections/50416
         if 'id' not in obj and 'gid' in obj:
-            obj['id'] = int(obj['gid'])
+            # Fallback to string if `gid` stops being int-convertible
+            obj['id'] = self._safe_int_convert(obj, 'gid')
         for k, v in obj.items():
             # Recurse into sub-objects (e.g., 'workspace')
             if isinstance(v, dict):

--- a/tap_asana/streams/base.py
+++ b/tap_asana/streams/base.py
@@ -152,12 +152,14 @@ class Stream():
         return fn.find_all()
 
     def _safe_int_convert(self, obj, key):
+        # HACK: This is a workaround method
         try:
             return int(obj[key])
         except:
             return obj[key]
 
     def _patch_ids(self, obj):
+        # HACK: This is a workaround method
         # NB: Asana has moved to a string 'gid' in place of the existing int 'id'
         # - This is a workaround to keep the existing functionality
         # More Info: https://forum.asana.com/t/reminder-about-two-big-upcoming-api-changes-string-ids-and-new-sections/50416

--- a/tap_asana/streams/base.py
+++ b/tap_asana/streams/base.py
@@ -151,9 +151,21 @@ class Stream():
             return fn.find_all(**query_params)
         return fn.find_all()
 
+    def _patch_ids(self, obj):
+        # NB: Asana has moved to a string 'gid' in place of the existing int 'id'
+        # - This is a workaround to keep the existing functionality
+        # More Info: https://forum.asana.com/t/reminder-about-two-big-upcoming-api-changes-string-ids-and-new-sections/50416
+        if 'id' not in obj and 'gid' in obj:
+            obj['id'] = int(obj['gid'])
+        for k, v in obj.items():
+            # Recurse into sub-objects (e.g., 'workspace')
+            if isinstance(v, dict):
+                obj[k] = self._patch_ids(v)
+        return obj
 
     def sync(self):
         """Yield's processed SDK object dicts to the caller.
         """
         for obj in self.get_objects():
+            obj = self._patch_ids(obj)
             yield obj

--- a/test/test_string_id_workaround.py
+++ b/test/test_string_id_workaround.py
@@ -1,0 +1,75 @@
+import unittest
+
+from tap_asana.streams.base import Stream
+
+class TestStringIdWorkaround(unittest.TestCase):
+    stream = Stream()
+
+    def test_patch_ids_has_no_effect_in_current_state(self):
+        test_obj = {'color': 'dark-purple',
+                    'created_at': '2020-02-10T23:38:58.382Z',
+                    'followers': [],
+                    'gid': '9991311522123467',
+                    'id': 9991311522123467,
+                    'name': 'new_tag',
+                    'notes': '',
+                    'workspace': {'gid': '99916671235410',
+                                  'id': 99916671235410,
+                                  'resource_type': 'workspace'}}
+        expected = {'color': 'dark-purple',
+                    'created_at': '2020-02-10T23:38:58.382Z',
+                    'followers': [],
+                    'gid': '9991311522123467',
+                    'id': 9991311522123467,
+                    'name': 'new_tag',
+                    'notes': '',
+                    'workspace': {'gid': '99916671235410',
+                                  'id': 99916671235410,
+                                  'resource_type': 'workspace'}}
+        actual = self.stream._patch_ids(test_obj)
+        self.assertEqual(expected, actual)
+        
+        
+    def test_patch_ids_works_with_int_gid_no_id(self):
+        test_obj = {'color': 'dark-purple',
+                    'created_at': '2020-02-10T23:38:58.382Z',
+                    'followers': [],
+                    'gid': '9991311522123467',
+                    'name': 'new_tag',
+                    'notes': '',
+                    'workspace': {'gid': '99916671235410',
+                                  'resource_type': 'workspace'}}
+        expected = {'color': 'dark-purple',
+                    'created_at': '2020-02-10T23:38:58.382Z',
+                    'followers': [],
+                    'gid': '9991311522123467',
+                    'id': 9991311522123467,
+                    'name': 'new_tag',
+                    'notes': '',
+                    'workspace': {'gid': '99916671235410',
+                                  'id': 99916671235410,
+                                  'resource_type': 'workspace'}}
+        actual = self.stream._patch_ids(test_obj)
+        self.assertEqual(expected, actual)
+
+    def test_patch_ids_works_with_string_gid_no_id(self):
+        test_obj = {'color': 'dark-purple',
+                    'created_at': '2020-02-10T23:38:58.382Z',
+                    'followers': [],
+                    'gid': 'abc123hereisastring',
+                    'name': 'new_tag',
+                    'notes': '',
+                    'workspace': {'gid': 'aworkspaceidstring',
+                                  'resource_type': 'workspace'}}
+        expected = {'color': 'dark-purple',
+                    'created_at': '2020-02-10T23:38:58.382Z',
+                    'followers': [],
+                    'gid': 'abc123hereisastring',
+                    'id': 'abc123hereisastring',
+                    'name': 'new_tag',
+                    'notes': '',
+                    'workspace': {'gid': 'aworkspaceidstring',
+                                  'id': 'aworkspaceidstring',
+                                  'resource_type': 'workspace'}}
+        actual = self.stream._patch_ids(test_obj)
+        self.assertEqual(expected, actual)


### PR DESCRIPTION
# Description of change
Asana is deprecating the integer `id` field tomorrow in favor of a string `gid`. This is outlined here:

https://forum.asana.com/t/reminder-about-two-big-upcoming-api-changes-string-ids-and-new-sections/50416

In testing, the `gid` value was just a stringified version of the current `int`, so in order to keep the tap functionality consistent, this PR implements a workaround that will populate the `id` field if it is not present.

Additionally, if the gid field stops being "int-able", this PR will fallback to making the value a string.

# Manual QA steps
 - Ran through tests without the workaround header that's currently in place to simulate release of this feature on Asana's end.
 
# Risks
 - Low, the integration will break due to null PK if nothing is done.
 
# Rollback steps
 - revert this branch
