### PR TITLE
Add start_on field to tasks schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.0.1
+ * Added start_on field to tasks schema
+
 ## 2.0.0
  * Deprecated `id` for `gid` [#16](https://github.com/singer-io/tap-asana/pull/16)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-asana",
-    version="2.0.0",
+    version="2.0.1",
     description="Singer.io tap for extracting Asana data",
     author="Stitch",
     url="http://github.com/singer-io/tap-asana",

--- a/tap_asana/schemas/tasks.json
+++ b/tap_asana/schemas/tasks.json
@@ -70,6 +70,13 @@
       ],
       "format": "date-time"
     },
+    "start_on": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "date-time"
+    },
     "external": {
       "type": [
         "null",

--- a/tap_asana/streams/tasks.py
+++ b/tap_asana/streams/tasks.py
@@ -19,6 +19,7 @@ class Tasks(Stream):
     "tags",
     "due_on",
     "due_at",
+    "start_on",
     "external",
     "followers",
     "hearted",


### PR DESCRIPTION
# Description of change
Add field `start_on` to tasks

# Manual QA steps
Ran locally against production Asana data
 
# Risks
 
# Rollback steps
 Revert this branch
