### PR TITLE
Add custom_fields to projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,6 +137,9 @@ pip-selfcheck.json
 # End of https://www.gitignore.io/api/python
 
 # Tap config.
+tap_target_commands.sh
+tap_config.json
+target_config.json
 catalog*.json
 config*.json
 state*.json

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.pythonPath": "/Users/jeff.huth/.virtualenvs/tap-asana/bin/python"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.0.2
+ * Added `custom_fields` to projects schema
+
 ## 2.0.1
  * Added start_on field to tasks schema
 

--- a/setup.py
+++ b/setup.py
@@ -3,15 +3,15 @@ from setuptools import setup
 
 setup(
     name="tap-asana",
-    version="2.0.1",
+    version="2.0.2",
     description="Singer.io tap for extracting Asana data",
     author="Stitch",
     url="http://github.com/singer-io/tap-asana",
     classifiers=["Programming Language :: Python :: 3 :: Only"],
     py_modules=["tap_asana"],
     install_requires=[
-        "asana==0.8.2",
-        "singer-python==5.4.1"
+        "asana==0.10.0",
+        'singer-python==5.9.0'
     ],
     extras_require={
         'dev': [

--- a/tap_asana/schemas/projects.json
+++ b/tap_asana/schemas/projects.json
@@ -178,6 +178,175 @@
           ]
         }
       }
+    },
+    "custom_fields": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": [
+          "object"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "gid": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "resource_type": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "name": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "resource_subtype": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "type": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "enum_options": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "type": [
+                "object"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "gid": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "resource_type": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "name": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "enabled": {
+                  "type": [
+                    "null",
+                    "boolean"
+                  ]
+                },
+                "color": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                }
+              }
+            }
+          },
+          "enum_value": {
+            "type": [
+              "null",
+              "object"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "gid": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "resource_type": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "name": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "enabled": {
+                "type": [
+                  "null",
+                  "boolean"
+                ]
+              },
+              "color": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              }
+            }
+          },
+          "enabled": {
+            "type": [
+              "null",
+              "boolean"
+            ]
+          },
+          "text_value": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "number_value": {
+            "type": [
+              "null",
+              "number"
+            ]
+          },
+          "description": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "precision": {
+            "type": [
+              "null",
+              "integer"
+            ]
+          },
+          "is_global_to_workspace": {
+            "type": [
+              "null",
+              "boolean"
+            ]
+          },
+          "has_notifications_enabled": {
+            "type": [
+              "null",
+              "boolean"
+            ]
+          }
+        }
+      }
     }
   }
 }

--- a/tap_asana/streams/projects.py
+++ b/tap_asana/streams/projects.py
@@ -13,6 +13,7 @@ class Projects(Stream):
     "gid",
     "owner",
     "current_status",
+    "custom_fields",
     "due_date",
     "created_at",
     "modified_at",


### PR DESCRIPTION
# Description of change
Added `custom_fields` to projects schema. These are available as a part of Portfolios (groups of Projects) and require a Business tier subscription. Adjusted projects.py and projects.json (schema).

# Manual QA steps
After code changes, ran singer-discover, singer-check-tap, and sync data to target-stitch. No errors.
 
# Risks
Low - adds 1 json array field to Projects.
 
# Rollback steps
Rever to v.2.0.1
