### PR TITLE
Add Resource Subtype Field to Tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.0.23
+ * Added `resource_subtype` field to tasks schema
+
 ## 2.0.2
  * Added `custom_fields` to projects schema
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-asana",
-    version="2.0.2",
+    version="2.0.3",
     description="Singer.io tap for extracting Asana data",
     author="Stitch",
     url="http://github.com/singer-io/tap-asana",

--- a/tap_asana/schemas/tasks.json
+++ b/tap_asana/schemas/tasks.json
@@ -204,6 +204,12 @@
         "string"
       ]
     },
+    "resource_subtype": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
     "tags": {
       "type": [
         "null",

--- a/tap_asana/streams/tasks.py
+++ b/tap_asana/streams/tasks.py
@@ -31,7 +31,8 @@ class Tasks(Stream):
     "projects",
     "parent",
     "workspace",
-    "memberships"
+    "memberships",
+    "resource_subtype"
   ]
 
 


### PR DESCRIPTION
This change adds the resource_subtype field to tasks. This field
indicates whether the task is a Milestone or not.

Fixes #25


# Description of change
(write a short description or paste a link to JIRA)

# Manual QA steps
 Ran tap to verify output 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch