### PR TITLE
Enable Stream Selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.1.1
+ * Fixed issue where stream selection wasn't applying [#29](https://github.com/singer-io/tap-asana/pull/29)
+
 ## 2.1.0
  * Added endpoints: `portfolios`, `sections`, `stories`, and `teams`. Add missing fields to other endpoints.
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-asana",
-    version="2.1.0",
+    version="2.1.1",
     description="Singer.io tap for extracting Asana data",
     author="Stitch",
     url="http://github.com/singer-io/tap-asana",

--- a/tap_asana/context.py
+++ b/tap_asana/context.py
@@ -21,7 +21,6 @@ class Context():
 
     @classmethod
     def is_selected(cls, stream_name):
-        return True
-        # stream = cls.get_catalog_entry(stream_name)
-        # stream_metadata = metadata.to_map(stream['metadata'])
-        # return metadata.get(stream_metadata, (), 'selected')
+        stream = cls.get_catalog_entry(stream_name)
+        stream_metadata = metadata.to_map(stream['metadata'])
+        return metadata.get(stream_metadata, (), 'selected')


### PR DESCRIPTION
# Description of change
It seems this was missed in the initial tap review. Changing the stream_selection code on `Context` to actually respect `selected` metadata.

# Manual QA steps
 - Ran through the code with and without a selection, and confirms it correctly skipped the unselected stream.
 
# Risks
 - Low, it's pretty broken right now.
 
# Rollback steps
 - revert this branch and release new patch version
