### PR TITLE
use tap-tester-v4 image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:tap-tester
+      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:tap-tester-v4
     steps:
       - checkout
       - run:


### PR DESCRIPTION
# Description of change
Use the v4 tap-tester image. The idea is this will prevent failures to source the environment during nightly builds.

# Manual QA steps
 - None
 
# Risks
 - None, change to tap-tester image.
 
# Rollback steps
 - revert this branch
