### PR TITLE
Update testing infrastructure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,7 @@ jobs:
           no_output_timeout: 60m
           command: |
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
+            uv pip install --upgrade awscli
             aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox dev_env.sh
             source dev_env.sh
             run-test --tap=tap-asana tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,9 +34,9 @@ jobs:
           name: 'Integration Tests'
           no_output_timeout: 60m
           command: |
+            source /usr/local/share/virtualenvs/tap-tester/bin/activate
             aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox dev_env.sh
             source dev_env.sh
-            source /usr/local/share/virtualenvs/tap-tester/bin/activate
             run-test --tap=tap-asana tests
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,20 +10,20 @@ jobs:
           command: |
             uv venv --python=3.9 /usr/local/share/virtualenvs/tap-asana
             source /usr/local/share/virtualenvs/tap-asana/bin/activate
-            pip install -U 'pip<19.2' 'setuptools<51.0.0'
-            pip install .[test]
+            uv pip install -U 'pip<19.2' 'setuptools<51.0.0'
+            uv pip install .[test]
       - run:
           name: 'Unit Tests'
           command: |
             source /usr/local/share/virtualenvs/tap-asana/bin/activate
-            pip install nose coverage parameterized
+            uv pip install nose coverage parameterized
             nosetests --with-coverage --cover-erase --cover-package=tap_asana --cover-html-dir=htmlcov tests/unittests
             coverage html
       - store_test_results:
           path: test_output/report.xml
       - store_artifacts:
           path: htmlcov
-            pip install .[test]
+            uv pip install .[test]
       - run:
           name: 'pylint'
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
           name: 'pylint'
           command: |
             source /usr/local/share/virtualenvs/tap-asana/bin/activate
-            pylint tap_asana -d bad-indentation,missing-docstring,line-too-long,no-member,use-yield-from
+            pylint tap_asana -d bad-indentation,missing-docstring,line-too-long,no-member,use-yield-from,too-many-positional-arguments
       - add_ssh_keys
       - run:
           name: 'Integration Tests'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
           name: 'pylint'
           command: |
             source /usr/local/share/virtualenvs/tap-asana/bin/activate
-            pylint tap_asana -d bad-indentation,missing-docstring,line-too-long,no-member
+            pylint tap_asana -d bad-indentation,missing-docstring,line-too-long,no-member,use-yield-from
       - add_ssh_keys
       - run:
           name: 'Integration Tests'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
       - run:
           name: 'Setup virtual env'
           command: |
-            uv venv --python=3.9 /usr/local/share/virtualenvs/tap-asana
+            uv venv --python 3.9 /usr/local/share/virtualenvs/tap-asana
             source /usr/local/share/virtualenvs/tap-asana/bin/activate
             uv pip install -U 'pip<19.2' 'setuptools<51.0.0'
             uv pip install .[test]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
       - run:
           name: 'Setup virtual env'
           command: |
-            python3 -mvenv /usr/local/share/virtualenvs/tap-asana
+            uv venv --python=3.9 /usr/local/share/virtualenvs/tap-asana
             source /usr/local/share/virtualenvs/tap-asana/bin/activate
             pip install -U 'pip<19.2' 'setuptools<51.0.0'
             pip install .[test]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:stitch-tap-tester
+      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:stitch-tap-tester-uv
     steps:
       - checkout
       - run:


### PR DESCRIPTION
This PR updates the CircleCI config to use `uv` to create and manage virtualenvs and python dependencies