### PR TITLE
Adds forced-replication-method & parent-tap-stream-id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.4.0
+ * Adds `forced-replication-method` and `parent-tap-stream-id` as discoverable metadata [SAC-28812]
+
 ## 2.3.0
  * New Stream Inclusion: Subtasks [#56](https://github.com/singer-io/tap-asana/pull/56)
  

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-asana",
-    version="2.3.0",
+    version="2.4.0",
     description="Singer.io tap for extracting Asana data",
     author="Stitch",
     url="http://github.com/singer-io/tap-asana",

--- a/tap_asana/__init__.py
+++ b/tap_asana/__init__.py
@@ -57,6 +57,9 @@ def get_discovery_metadata(stream, schema):
         mdata, (), "forced-replication-method", stream.replication_method
     )
 
+    if hasattr(stream, 'parent_stream_id') and stream.parent_stream_id:
+        mdata = metadata.write(mdata, (), "parent-tap-stream-id", stream.parent_stream_id)
+
     if stream.replication_key:
         mdata = metadata.write(
             mdata, (), "valid-replication-keys", [stream.replication_key]

--- a/tap_asana/streams/base.py
+++ b/tap_asana/streams/base.py
@@ -125,6 +125,7 @@ class Stream():
     replication_method = None
     replication_key = None
     key_properties = ["gid"]
+    parent_stream_id = None
     # Controls which SDK object we use to call the API by default.
 
     def __init__(self):

--- a/tap_asana/streams/sections.py
+++ b/tap_asana/streams/sections.py
@@ -5,6 +5,7 @@ from tap_asana.streams.base import Stream
 class Sections(Stream):
     replication_method = "FULL_TABLE"
     name = "sections"
+    parent_stream_id = "projects"
 
     fields = [
         "gid",

--- a/tap_asana/streams/stories.py
+++ b/tap_asana/streams/stories.py
@@ -6,6 +6,7 @@ class Stories(Stream):
     name = "stories"
     replication_method = "INCREMENTAL"
     replication_key = "created_at"
+    parent_stream_id = "tasks"
 
     fields = [
         "gid",

--- a/tap_asana/streams/subtasks.py
+++ b/tap_asana/streams/subtasks.py
@@ -11,6 +11,7 @@ class SubTasks(Stream):
     name = "subtasks"
     replication_key = "modified_at"
     replication_method = "INCREMENTAL"
+    parent_stream_id = "tasks"
     fields = [
         "gid",
         "resource_type",


### PR DESCRIPTION
# Description of change
Closes: [SAC-28812: Add New Metadata to tap-asana](https://qlik-dev.atlassian.net/browse/SAC-28812)

Both required metadata fields are being provided in discovery mode

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool


#### I have tested changes with [stitchdata/tap-tester](https://github.com/stitchdata/tap-tester)

test_discovery has succeeded, test_all_fields failed with "Payment required" error message. I think that's irrelevant to the changes made.

<details>
  <summary>test log</summary>

     at 14:24:15 ❯ bin/run-test --tap=/usr/local/share/virtualenvs/tap-asana/bin/tap-asana /opt/code/tap-asana/tests/test_discovery.py
     STITCH_TAP_PATH=/usr/local/share/virtualenvs/tap-asana/bin/tap-asana

     tap-tester --path "/opt/code/tap-asana/tests/test_discovery.py"
     2025-09-16 21:24:21,173 TapTester - INFO     Single test file found: test_discovery.py
     2025-09-16 21:24:21,174 TapTester - INFO     Running 1 test file(s) from /opt/code/tap-asana/tests/test_discovery.py
     2025-09-16 21:24:21,174 TapTester - INFO     clearing invalid token attempts from cores services
     2025-09-16 21:24:21,184 TapTester - INFO     cleared [0] invalid token attempts
     2025-09-16 21:24:21,754 TapTester - INFO     Found 1 existing connections for scenario name tap_tester_asana_discovery_test
     2025-09-16 21:24:21,754 TapTester - INFO     deleting old connection 166
     2025-09-16 21:24:22,180 TapTester - INFO     Clearing state and catalog for connection: 167
     2025-09-16 21:24:22,200 TapTester - INFO     asserting state to {}
     2025-09-16 21:24:22,219 TapTester - INFO     state asserted
     2025-09-16 21:24:22,219 TapTester - INFO     new connection synthesized: 167
     2025-09-16 21:24:22,220 TapTester - INFO     running tap in check mode
     2025-09-16 21:24:22,220 TapTester - INFO     **************************************************************************************************************
     2025-09-16 21:24:22,493 TapTester - INFO     2025-09-16 21:24:22,493Z   main - INFO Running tap-asana version 2.4.0 and target-stitch version 4.0.2 on architecture Unknown
     2025-09-16 21:24:23,298 TapTester - INFO     2025-09-16 21:24:23,298Z   main - INFO Starting tap to discover schemas: /usr/local/share/virtualenvs/tap-asana/bin/tap-asana --config /tmp/tap_discover_config.json --discover
     2025-09-16 21:24:24,004 TapTester - INFO     2025-09-16 21:24:24,004Z    tap - INFO Starting discover
     2025-09-16 21:24:24,007 TapTester - INFO     2025-09-16 21:24:24,007Z    tap - INFO Finished discover
     2025-09-16 21:24:24,072 TapTester - INFO     2025-09-16 21:24:24,072Z   main - INFO Tap exited normally.
     2025-09-16 21:24:24,076 TapTester - INFO     2025-09-16 21:24:24,076Z   main - INFO Saving list of discovered streams
     2025-09-16 21:24:24,088 TapTester - INFO     2025-09-16 21:24:24,087Z   main - INFO Saving structure of stream projects (tap_stream_id: projects)
     2025-09-16 21:24:24,118 TapTester - INFO     2025-09-16 21:24:24,118Z   main - INFO Saving structure of stream portfolios (tap_stream_id: portfolios)
     2025-09-16 21:24:24,140 TapTester - INFO     2025-09-16 21:24:24,140Z   main - INFO Saving structure of stream tags (tap_stream_id: tags)
     2025-09-16 21:24:24,155 TapTester - INFO     2025-09-16 21:24:24,155Z   main - INFO Saving structure of stream teams (tap_stream_id: teams)
     2025-09-16 21:24:24,170 TapTester - INFO     2025-09-16 21:24:24,170Z   main - INFO Saving structure of stream subtasks (tap_stream_id: subtasks)
     2025-09-16 21:24:24,202 TapTester - INFO     2025-09-16 21:24:24,202Z   main - INFO Saving structure of stream tasks (tap_stream_id: tasks)
     2025-09-16 21:24:24,232 TapTester - INFO     2025-09-16 21:24:24,232Z   main - INFO Saving structure of stream stories (tap_stream_id: stories)
     2025-09-16 21:24:24,270 TapTester - INFO     2025-09-16 21:24:24,270Z   main - INFO Saving structure of stream sections (tap_stream_id: sections)
     2025-09-16 21:24:24,287 TapTester - INFO     2025-09-16 21:24:24,287Z   main - INFO Saving structure of stream workspaces (tap_stream_id: workspaces)
     2025-09-16 21:24:24,302 TapTester - INFO     2025-09-16 21:24:24,301Z   main - INFO Saving structure of stream users (tap_stream_id: users)
     2025-09-16 21:24:24,318 TapTester - INFO     2025-09-16 21:24:24,318Z   main - INFO Starting tap: /usr/local/share/virtualenvs/tap-asana/bin/tap-asana --config /tmp/tap_config.json
     2025-09-16 21:24:24,746 TapTester - INFO     2025-09-16 21:24:24,745Z    tap - INFO Starting discover
     2025-09-16 21:24:24,749 TapTester - INFO     2025-09-16 21:24:24,749Z    tap - INFO Finished discover
     2025-09-16 21:24:24,749 TapTester - INFO     2025-09-16 21:24:24,749Z    tap - INFO Skipping stream: projects
     2025-09-16 21:24:24,749 TapTester - INFO     2025-09-16 21:24:24,749Z    tap - INFO Skipping stream: portfolios
     2025-09-16 21:24:24,749 TapTester - INFO     2025-09-16 21:24:24,749Z    tap - INFO Skipping stream: tags
     2025-09-16 21:24:24,749 TapTester - INFO     2025-09-16 21:24:24,749Z    tap - INFO Skipping stream: teams
     2025-09-16 21:24:24,749 TapTester - INFO     2025-09-16 21:24:24,749Z    tap - INFO Skipping stream: subtasks
     2025-09-16 21:24:24,749 TapTester - INFO     2025-09-16 21:24:24,749Z    tap - INFO Skipping stream: tasks
     2025-09-16 21:24:24,749 TapTester - INFO     2025-09-16 21:24:24,749Z    tap - INFO Skipping stream: stories
     2025-09-16 21:24:24,749 TapTester - INFO     2025-09-16 21:24:24,749Z    tap - INFO Skipping stream: sections
     2025-09-16 21:24:24,749 TapTester - INFO     2025-09-16 21:24:24,749Z    tap - INFO Skipping stream: workspaces
     2025-09-16 21:24:24,749 TapTester - INFO     2025-09-16 21:24:24,749Z    tap - INFO Skipping stream: users
     2025-09-16 21:24:24,749 TapTester - INFO     2025-09-16 21:24:24,749Z    tap - INFO ----------------------
     2025-09-16 21:24:24,749 TapTester - INFO     2025-09-16 21:24:24,749Z    tap - INFO ----------------------
     2025-09-16 21:24:24,812 TapTester - INFO     2025-09-16 21:24:24,812Z   main - INFO Connection check succeeded
     2025-09-16 21:24:24,813 TapTester - INFO     2025-09-16 21:24:24,813Z   main - WARNING Not publishing metrics because some environment variables are not configured
     2025-09-16 21:24:24,813 TapTester - INFO     2025-09-16 21:24:24,813Z   main - INFO No tunnel subprocess to tear down
     2025-09-16 21:24:24,813 TapTester - INFO     2025-09-16 21:24:24,813Z   main - INFO Exit status is: Discovery succeeded.
     2025-09-16 21:24:29,963 TapTester - INFO     **************************************************************************************************************
     2025-09-16 21:24:29,963 TapTester - INFO     check mode exited succesfully
     2025-09-16 21:24:29,970 TapTester - INFO     exit_status: {'target_exit_status': None, 'tap_error_message': None, 'check_exit_status': 0, 'name': '3-167-1758057862-checks', 'start_time': None, 'mode': 'check', 'tap_exit_status': None, 'target_error_message': None, 'discovery_exit_status': 0, 'completion_time': '2025-09-16T21:24:24Z', 'error': False, 'discovery_error_message': None}
     2025-09-16 21:24:29,971 TapTester - INFO     OK: discovery_exit_status for sync job(3-167-1758057862-checks) is 0 or None
     2025-09-16 21:24:29,971 TapTester - INFO     OK: check_exit_status for job(3-167-1758057862-checks) is 0 or none
     2025-09-16 21:24:29,971 TapTester - INFO     OK: target_exit_status for job(3-167-1758057862-checks) is None
     2025-09-16 21:24:29,971 TapTester - INFO     OK: tap_exit_status for job(3-167-1758057862-checks) is None
     2025-09-16 21:24:29,971 TapTester - INFO     searching for schemas for 167
     2025-09-16 21:24:29,985 TapTester - INFO     {'stories', 'teams', 'sections', 'portfolios', 'tags', 'subtasks', 'tasks', 'users', 'workspaces', 'projects'}
     2025-09-16 21:24:29,985 TapTester - INFO     discovered schemas are OK
     2025-09-16 21:24:30,085 TapTester - INFO     ***** Test Results *****
     ----------------------------------------------------------------------
     Ran 1 tests in 8s

     OK
     ubuntu in 🌐 ip-10-10-11-134 in tap-tester via 🐍 v3.11.13 (tap-tester) on ☁️  (us-east-1) took 9s
     at 14:24:30 ❯ bin/run-test --tap=/usr/local/share/virtualenvs/tap-asana/bin/tap-asana /opt/code/tap-asana/tests/test_all_fields.py
     STITCH_TAP_PATH=/usr/local/share/virtualenvs/tap-asana/bin/tap-asana

     tap-tester --path "/opt/code/tap-asana/tests/test_all_fields.py"
     2025-09-16 21:24:41,496 TapTester - INFO     Single test file found: test_all_fields.py
     2025-09-16 21:24:41,498 TapTester - INFO     Running 1 test file(s) from /opt/code/tap-asana/tests/test_all_fields.py
     2025-09-16 21:24:41,498 TapTester - INFO     clearing invalid token attempts from cores services
     2025-09-16 21:24:41,508 TapTester - INFO     cleared [0] invalid token attempts
     2025-09-16 21:24:41,879 TapTester - INFO     Found 0 existing connections for scenario name tap_tester_asana_all_fields_test
     2025-09-16 21:24:42,262 TapTester - INFO     Clearing state and catalog for connection: 168
     2025-09-16 21:24:42,286 TapTester - INFO     asserting state to {}
     2025-09-16 21:24:42,301 TapTester - INFO     state asserted
     2025-09-16 21:24:42,301 TapTester - INFO     new connection synthesized: 168
     2025-09-16 21:24:42,302 TapTester - INFO     running tap in check mode
     2025-09-16 21:24:42,302 TapTester - INFO     **************************************************************************************************************
     2025-09-16 21:24:42,596 TapTester - INFO     2025-09-16 21:24:42,595Z   main - INFO Running tap-asana version 2.4.0 and target-stitch version 4.0.2 on architecture Unknown
     2025-09-16 21:24:43,396 TapTester - INFO     2025-09-16 21:24:43,396Z   main - INFO Starting tap to discover schemas: /usr/local/share/virtualenvs/tap-asana/bin/tap-asana --config /tmp/tap_discover_config.json --discover
     2025-09-16 21:24:43,878 TapTester - INFO     2025-09-16 21:24:43,878Z    tap - INFO Starting discover
     2025-09-16 21:24:43,881 TapTester - INFO     2025-09-16 21:24:43,881Z    tap - INFO Finished discover
     2025-09-16 21:24:43,949 TapTester - INFO     2025-09-16 21:24:43,949Z   main - INFO Tap exited normally.
     2025-09-16 21:24:43,953 TapTester - INFO     2025-09-16 21:24:43,953Z   main - INFO Saving list of discovered streams
     2025-09-16 21:24:43,965 TapTester - INFO     2025-09-16 21:24:43,964Z   main - INFO Saving structure of stream projects (tap_stream_id: projects)
     2025-09-16 21:24:43,989 TapTester - INFO     2025-09-16 21:24:43,989Z   main - INFO Saving structure of stream portfolios (tap_stream_id: portfolios)
     2025-09-16 21:24:44,008 TapTester - INFO     2025-09-16 21:24:44,007Z   main - INFO Saving structure of stream tags (tap_stream_id: tags)
     2025-09-16 21:24:44,022 TapTester - INFO     2025-09-16 21:24:44,021Z   main - INFO Saving structure of stream teams (tap_stream_id: teams)
     2025-09-16 21:24:44,034 TapTester - INFO     2025-09-16 21:24:44,034Z   main - INFO Saving structure of stream subtasks (tap_stream_id: subtasks)
     2025-09-16 21:24:44,060 TapTester - INFO     2025-09-16 21:24:44,060Z   main - INFO Saving structure of stream tasks (tap_stream_id: tasks)
     2025-09-16 21:24:44,086 TapTester - INFO     2025-09-16 21:24:44,085Z   main - INFO Saving structure of stream stories (tap_stream_id: stories)
     2025-09-16 21:24:44,123 TapTester - INFO     2025-09-16 21:24:44,123Z   main - INFO Saving structure of stream sections (tap_stream_id: sections)
     2025-09-16 21:24:44,137 TapTester - INFO     2025-09-16 21:24:44,137Z   main - INFO Saving structure of stream workspaces (tap_stream_id: workspaces)
     2025-09-16 21:24:44,148 TapTester - INFO     2025-09-16 21:24:44,148Z   main - INFO Saving structure of stream users (tap_stream_id: users)
     2025-09-16 21:24:44,160 TapTester - INFO     2025-09-16 21:24:44,160Z   main - INFO Starting tap: /usr/local/share/virtualenvs/tap-asana/bin/tap-asana --config /tmp/tap_config.json
     2025-09-16 21:24:44,566 TapTester - INFO     2025-09-16 21:24:44,566Z    tap - INFO Starting discover
     2025-09-16 21:24:44,569 TapTester - INFO     2025-09-16 21:24:44,569Z    tap - INFO Finished discover
     2025-09-16 21:24:44,569 TapTester - INFO     2025-09-16 21:24:44,569Z    tap - INFO Skipping stream: projects
     2025-09-16 21:24:44,569 TapTester - INFO     2025-09-16 21:24:44,569Z    tap - INFO Skipping stream: portfolios
     2025-09-16 21:24:44,569 TapTester - INFO     2025-09-16 21:24:44,569Z    tap - INFO Skipping stream: tags
     2025-09-16 21:24:44,569 TapTester - INFO     2025-09-16 21:24:44,569Z    tap - INFO Skipping stream: teams
     2025-09-16 21:24:44,569 TapTester - INFO     2025-09-16 21:24:44,569Z    tap - INFO Skipping stream: subtasks
     2025-09-16 21:24:44,569 TapTester - INFO     2025-09-16 21:24:44,569Z    tap - INFO Skipping stream: tasks
     2025-09-16 21:24:44,569 TapTester - INFO     2025-09-16 21:24:44,569Z    tap - INFO Skipping stream: stories
     2025-09-16 21:24:44,626 TapTester - INFO     2025-09-16 21:24:44,569Z    tap - INFO Skipping stream: sections
     2025-09-16 21:24:44,626 TapTester - INFO     2025-09-16 21:24:44,569Z    tap - INFO Skipping stream: workspaces
     2025-09-16 21:24:44,626 TapTester - INFO     2025-09-16 21:24:44,569Z    tap - INFO Skipping stream: users
     2025-09-16 21:24:44,626 TapTester - INFO     2025-09-16 21:24:44,569Z    tap - INFO ----------------------
     2025-09-16 21:24:44,626 TapTester - INFO     2025-09-16 21:24:44,569Z    tap - INFO ----------------------
     2025-09-16 21:24:44,626 TapTester - INFO     2025-09-16 21:24:44,626Z   main - INFO Connection check succeeded
     2025-09-16 21:24:49,769 TapTester - INFO     2025-09-16 21:24:44,626Z   main - WARNING Not publishing metrics because some environment variables are not configured
     2025-09-16 21:24:49,769 TapTester - INFO     2025-09-16 21:24:44,626Z   main - INFO No tunnel subprocess to tear down
     2025-09-16 21:24:49,769 TapTester - INFO     2025-09-16 21:24:44,626Z   main - INFO Exit status is: Discovery succeeded.
     2025-09-16 21:24:49,769 TapTester - INFO     **************************************************************************************************************
     2025-09-16 21:24:49,769 TapTester - INFO     check mode exited succesfully
     2025-09-16 21:24:49,776 TapTester - INFO     exit_status: {'target_exit_status': None, 'tap_error_message': None, 'check_exit_status': 0, 'name': '3-168-1758057882-checks', 'start_time': None, 'mode': 'check', 'tap_exit_status': None, 'target_error_message': None, 'discovery_exit_status': 0, 'completion_time': '2025-09-16T21:24:44Z', 'error': False, 'discovery_error_message': None}
     2025-09-16 21:24:49,777 TapTester - INFO     OK: discovery_exit_status for sync job(3-168-1758057882-checks) is 0 or None
     2025-09-16 21:24:49,777 TapTester - INFO     OK: check_exit_status for job(3-168-1758057882-checks) is 0 or none
     2025-09-16 21:24:49,777 TapTester - INFO     OK: target_exit_status for job(3-168-1758057882-checks) is None
     2025-09-16 21:24:49,777 TapTester - INFO     OK: tap_exit_status for job(3-168-1758057882-checks) is None
     2025-09-16 21:24:49,777 TapTester - INFO     searching for schemas for 168
     2025-09-16 21:24:49,788 TapTester - INFO     {'tasks', 'portfolios', 'tags', 'workspaces', 'subtasks', 'stories', 'users', 'sections', 'teams', 'projects'}
     2025-09-16 21:24:49,788 TapTester - INFO     discovered schemas are OK
     2025-09-16 21:24:51,594 TapTester - INFO     running tap in sync mode
     2025-09-16 21:24:51,594 TapTester - INFO     **************************************************************************************************************
     2025-09-16 21:24:51,901 TapTester - INFO     2025-09-16 21:24:51,901Z   main - INFO Running tap-asana version 2.4.0 and target-stitch version 4.0.2 on architecture Unknown
     2025-09-16 21:24:52,821 TapTester - INFO     2025-09-16 21:24:52,821Z   main - INFO Starting tap to discover schemas: /usr/local/share/virtualenvs/tap-asana/bin/tap-asana --config /tmp/tap_discover_config.json --discover
     2025-09-16 21:24:53,271 TapTester - INFO     2025-09-16 21:24:53,271Z    tap - INFO Starting discover
     2025-09-16 21:24:53,274 TapTester - INFO     2025-09-16 21:24:53,273Z    tap - INFO Finished discover
     2025-09-16 21:24:53,327 TapTester - INFO     2025-09-16 21:24:53,327Z   main - INFO Tap exited normally.
     2025-09-16 21:24:53,331 TapTester - INFO     2025-09-16 21:24:53,331Z   main - INFO Saving list of discovered streams
     2025-09-16 21:24:53,338 TapTester - INFO     2025-09-16 21:24:53,337Z   main - INFO Saving structure of stream projects (tap_stream_id: projects)
     2025-09-16 21:24:53,355 TapTester - INFO     2025-09-16 21:24:53,355Z   main - INFO Saving structure of stream portfolios (tap_stream_id: portfolios)
     2025-09-16 21:24:53,373 TapTester - INFO     2025-09-16 21:24:53,373Z   main - INFO Saving structure of stream tags (tap_stream_id: tags)
     2025-09-16 21:24:53,386 TapTester - INFO     2025-09-16 21:24:53,386Z   main - INFO Saving structure of stream teams (tap_stream_id: teams)
     2025-09-16 21:24:53,398 TapTester - INFO     2025-09-16 21:24:53,398Z   main - INFO Saving structure of stream subtasks (tap_stream_id: subtasks)
     2025-09-16 21:24:53,417 TapTester - INFO     2025-09-16 21:24:53,417Z   main - INFO Saving structure of stream tasks (tap_stream_id: tasks)
     2025-09-16 21:24:53,435 TapTester - INFO     2025-09-16 21:24:53,435Z   main - INFO Saving structure of stream stories (tap_stream_id: stories)
     2025-09-16 21:24:53,455 TapTester - INFO     2025-09-16 21:24:53,454Z   main - INFO Saving structure of stream sections (tap_stream_id: sections)
     2025-09-16 21:24:53,466 TapTester - INFO     2025-09-16 21:24:53,466Z   main - INFO Saving structure of stream workspaces (tap_stream_id: workspaces)
     2025-09-16 21:24:53,476 TapTester - INFO     2025-09-16 21:24:53,476Z   main - INFO Saving structure of stream users (tap_stream_id: users)
     2025-09-16 21:24:53,486 TapTester - INFO     2025-09-16 21:24:53,486Z   main - INFO Writing catalog to file
     2025-09-16 21:24:53,516 TapTester - INFO     2025-09-16 21:24:53,516Z   main - INFO Selected fields for stream projects: followers, custom_field_settings, owner, due_date, created_from_template, members, start_on, completed, current_status, completed_by, name, archived, modified_at, workspace, project_brief, custom_fields, due_on, current_status_update, resource_type, html_notes, created_at, public, is_template, permalink_url, notes, team, default_view, color, gid, completed_at, icon
     2025-09-16 21:24:53,517 TapTester - INFO     2025-09-16 21:24:53,516Z   main - INFO Selected fields for stream portfolios: custom_field_settings, owner, members, start_on, created_by, name, workspace, custom_fields, due_on, current_status_update, resource_type, portfolio_items, created_at, public, is_template, permalink_url, color, gid
     2025-09-16 21:24:53,517 TapTester - INFO     2025-09-16 21:24:53,516Z   main - INFO Selected fields for stream tags: followers, name, workspace, resource_type, created_at, permalink_url, notes, color, gid
     2025-09-16 21:24:53,520 TapTester - INFO     2025-09-16 21:24:53,516Z   main - INFO Selected fields for stream teams: visibility, name, users, resource_type, html_description, permalink_url, organization, gid, description
     2025-09-16 21:24:53,520 TapTester - INFO     2025-09-16 21:24:53,516Z   main - INFO Selected fields for stream subtasks: followers, resource_subtype, due_at, hearted, dependencies, num_hearts, num_likes, parent, start_on, tags, completed, assignee_status, completed_by, dependents, liked, name, modified_at, workspace, custom_fields, due_on, is_rendered_as_separator, resource_type, assignee, html_notes, hearts, created_at, permalink_url, notes, projects, start_at, num_subtasks, gid, likes, completed_at, memberships
     2025-09-16 21:24:53,520 TapTester - INFO     2025-09-16 21:24:53,516Z   main - INFO Selected fields for stream tasks: followers, resource_subtype, due_at, hearted, dependencies, num_hearts, approval_status, num_likes, parent, start_on, tags, completed, assignee_status, completed_by, dependents, liked, name, modified_at, workspace, custom_fields, due_on, resource_type, assignee_section, assignee, html_notes, hearts, created_at, permalink_url, notes, projects, is_rendered_as_seperator, start_at, num_subtasks, gid, likes, completed_at, memberships, external
     2025-09-16 21:24:53,520 TapTester - INFO     2025-09-16 21:24:53,516Z   main - INFO Selected fields for stream sections: gid, resource_type, name, created_at, project, projects
     2025-09-16 21:24:53,520 TapTester - INFO     2025-09-16 21:24:53,517Z   main - INFO Selected fields for stream workspaces: gid, name, is_organization, resource_type, email_domains
     2025-09-16 21:24:53,520 TapTester - INFO     2025-09-16 21:24:53,517Z   main - INFO Selected fields for stream users: gid, resource_type, name, email, photo, workspaces
     2025-09-16 21:24:53,521 TapTester - INFO     2025-09-16 21:24:53,520Z   main - INFO Current state: {}
     2025-09-16 21:24:53,521 TapTester - INFO     2025-09-16 21:24:53,520Z   main - INFO Starting tap: /usr/local/share/virtualenvs/tap-asana/bin/tap-asana --config /tmp/tap_config.json --properties /tmp/properties.json --catalog /tmp/catalog.json --state /tmp/tap_state.json
     2025-09-16 21:24:53,521 TapTester - INFO     2025-09-16 21:24:53,521Z   main - INFO Starting target: /usr/local/share/virtualenvs/target-stitch/bin/target-stitch --dry-run --output-file /tmp/tap-tester-target-out.json
     2025-09-16 21:24:53,977 TapTester - INFO     2025-09-16 21:24:53,976Z    tap - INFO Syncing stream: projects
     2025-09-16 21:24:54,400 TapTester - INFO     2025-09-16 21:24:54,400Z    tap - /usr/local/share/virtualenvs/tap-asana/lib/python3.11/site-packages/asana/client.py:152: UserWarning: This request is affected by the "new_goal_memberships" deprecation. Please visit this url for more info: https://forum.asana.com/t/launched-team-sharing-for-goals/378601
     2025-09-16 21:24:54,400 TapTester - INFO     2025-09-16 21:24:54,400Z    tap - Adding "new_goal_memberships" to your "Asana-Enable" or "Asana-Disable" header will opt in/out to this deprecation and suppress this warning.
     2025-09-16 21:24:54,976 TapTester - INFO     2025-09-16 21:24:54,400Z    tap -   warnings.warn(message)
     2025-09-16 21:24:54,976 TapTester - INFO     2025-09-16 21:24:54,976Z    tap - INFO Syncing stream: portfolios
     2025-09-16 21:24:55,358 TapTester - INFO     2025-09-16 21:24:55,358Z    tap - CRITICAL Payment Required: Portfolios are only available for users in an Enterprise or Business plan.
     2025-09-16 21:24:55,358 TapTester - INFO     2025-09-16 21:24:55,358Z    tap - Traceback (most recent call last):
     2025-09-16 21:24:55,358 TapTester - INFO     2025-09-16 21:24:55,358Z    tap -   File "/usr/local/share/virtualenvs/tap-asana/bin/tap-asana", line 10, in <module>
     2025-09-16 21:24:55,358 TapTester - INFO     2025-09-16 21:24:55,358Z    tap -     sys.exit(main())
     2025-09-16 21:24:55,358 TapTester - INFO     2025-09-16 21:24:55,358Z    tap -              ^^^^^^
     2025-09-16 21:24:55,358 TapTester - INFO     2025-09-16 21:24:55,358Z    tap -   File "/usr/local/share/virtualenvs/tap-asana/lib/python3.11/site-packages/singer/utils.py", line 235, in wrapped
     2025-09-16 21:24:55,358 TapTester - INFO     2025-09-16 21:24:55,358Z    tap -     return fnc(*args, **kwargs)
     2025-09-16 21:24:55,358 TapTester - INFO     2025-09-16 21:24:55,358Z    tap -            ^^^^^^^^^^^^^^^^^^^^
     2025-09-16 21:24:55,358 TapTester - INFO     2025-09-16 21:24:55,358Z    tap -   File "/opt/code/tap-asana/tap_asana/__init__.py", line 201, in main
     2025-09-16 21:24:55,358 TapTester - INFO     2025-09-16 21:24:55,358Z    tap -     sync()
     2025-09-16 21:24:55,359 TapTester - INFO     2025-09-16 21:24:55,358Z    tap -   File "/opt/code/tap-asana/tap_asana/__init__.py", line 152, in sync
     2025-09-16 21:24:55,359 TapTester - INFO     2025-09-16 21:24:55,358Z    tap -     for rec in stream.sync():
     2025-09-16 21:24:55,359 TapTester - INFO     2025-09-16 21:24:55,358Z    tap -   File "/opt/code/tap-asana/tap_asana/streams/base.py", line 208, in sync
     2025-09-16 21:24:55,359 TapTester - INFO     2025-09-16 21:24:55,358Z    tap -     for obj in self.get_objects():
     2025-09-16 21:24:55,359 TapTester - INFO     2025-09-16 21:24:55,358Z    tap -   File "/opt/code/tap-asana/tap_asana/streams/portfolios.py", line 35, in get_objects
     2025-09-16 21:24:55,359 TapTester - INFO     2025-09-16 21:24:55,358Z    tap -     for portfolio in Context.asana.client.portfolios.get_portfolios(
     2025-09-16 21:24:55,359 TapTester - INFO     2025-09-16 21:24:55,358Z    tap -   File "/usr/local/share/virtualenvs/tap-asana/lib/python3.11/site-packages/asana/page_iterator.py", line 58, in items
     2025-09-16 21:24:55,359 TapTester - INFO     2025-09-16 21:24:55,358Z    tap -     for page in self:
     2025-09-16 21:24:55,359 TapTester - INFO     2025-09-16 21:24:55,358Z    tap -   File "/usr/local/share/virtualenvs/tap-asana/lib/python3.11/site-packages/asana/page_iterator.py", line 40, in __next__
     2025-09-16 21:24:55,359 TapTester - INFO     2025-09-16 21:24:55,358Z    tap -     result = self.get_initial()
     2025-09-16 21:24:55,359 TapTester - INFO     2025-09-16 21:24:55,358Z    tap -              ^^^^^^^^^^^^^^^^^^
     2025-09-16 21:24:55,359 TapTester - INFO     2025-09-16 21:24:55,359Z    tap -   File "/usr/local/share/virtualenvs/tap-asana/lib/python3.11/site-packages/backoff/_sync.py", line 94, in retry
     2025-09-16 21:24:55,359 TapTester - INFO     2025-09-16 21:24:55,359Z    tap -     ret = target(*args, **kwargs)
     2025-09-16 21:24:55,359 TapTester - INFO     2025-09-16 21:24:55,359Z    tap -           ^^^^^^^^^^^^^^^^^^^^^^^
     2025-09-16 21:24:55,359 TapTester - INFO     2025-09-16 21:24:55,359Z    tap -   File "/usr/local/share/virtualenvs/tap-asana/lib/python3.11/site-packages/backoff/_sync.py", line 94, in retry
     2025-09-16 21:24:55,360 TapTester - INFO     2025-09-16 21:24:55,359Z    tap -     ret = target(*args, **kwargs)
     2025-09-16 21:24:55,360 TapTester - INFO     2025-09-16 21:24:55,359Z    tap -           ^^^^^^^^^^^^^^^^^^^^^^^
     2025-09-16 21:24:55,360 TapTester - INFO     2025-09-16 21:24:55,359Z    tap -   File "/usr/local/share/virtualenvs/tap-asana/lib/python3.11/site-packages/backoff/_sync.py", line 94, in retry
     2025-09-16 21:24:55,360 TapTester - INFO     2025-09-16 21:24:55,359Z    tap -     ret = target(*args, **kwargs)
     2025-09-16 21:24:55,360 TapTester - INFO     2025-09-16 21:24:55,359Z    tap -           ^^^^^^^^^^^^^^^^^^^^^^^
     2025-09-16 21:24:55,360 TapTester - INFO     2025-09-16 21:24:55,359Z    tap -   [Previous line repeated 1 more time]
     2025-09-16 21:24:55,411 TapTester - INFO     2025-09-16 21:24:55,359Z    tap -   File "/opt/code/tap-asana/tap_asana/streams/base.py", line 109, in wrapper
     2025-09-16 21:24:55,412 TapTester - INFO     2025-09-16 21:24:55,359Z    tap -     return fnc(*args, **kwargs)
     2025-09-16 21:24:55,412 TapTester - INFO     2025-09-16 21:24:55,359Z    tap -            ^^^^^^^^^^^^^^^^^^^^
     2025-09-16 21:24:55,412 TapTester - INFO     2025-09-16 21:24:55,359Z    tap -   File "/usr/local/share/virtualenvs/tap-asana/lib/python3.11/site-packages/asana/page_iterator.py", line 69, in get_initial
     2025-09-16 21:24:55,412 TapTester - INFO     2025-09-16 21:24:55,359Z    tap -     return self.client.get(self.path, self.query, **self.options)
     2025-09-16 21:24:55,412 TapTester - INFO     2025-09-16 21:24:55,359Z    tap -            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     2025-09-16 21:24:55,412 TapTester - INFO     2025-09-16 21:24:55,359Z    tap -   File "/usr/local/share/virtualenvs/tap-asana/lib/python3.11/site-packages/asana/client.py", line 170, in get
     2025-09-16 21:24:55,412 TapTester - INFO     2025-09-16 21:24:55,359Z    tap -     return self.request('get', path, params=query, **options)
     2025-09-16 21:24:55,412 TapTester - INFO     2025-09-16 21:24:55,359Z    tap -            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     2025-09-16 21:24:55,412 TapTester - INFO     2025-09-16 21:24:55,359Z    tap -   File "/usr/local/share/virtualenvs/tap-asana/lib/python3.11/site-packages/asana/client.py", line 88, in request
     2025-09-16 21:24:55,412 TapTester - INFO     2025-09-16 21:24:55,359Z    tap -     raise STATUS_MAP[response.status_code](response)
     2025-09-16 21:24:55,412 TapTester - INFO     2025-09-16 21:24:55,359Z    tap - asana.error.PremiumOnlyError: Payment Required: Portfolios are only available for users in an Enterprise or Business plan.
     2025-09-16 21:24:55,412 TapTester - INFO     2025-09-16 21:24:55,411Z target - INFO LoggingHandler handle_batch
     2025-09-16 21:24:55,415 TapTester - INFO     2025-09-16 21:24:55,411Z target - INFO Saving batch with 73 messages for table projects to /tmp/tap-tester-target-out.json
     2025-09-16 21:24:55,415 TapTester - INFO     2025-09-16 21:24:55,415Z   main - INFO State update: adding bookmarks.projects.modified_at = "2025-06-18T03:03:31.039000"
     2025-09-16 21:24:55,415 TapTester - INFO     2025-09-16 21:24:55,415Z target - INFO ValidatingHandler handle_batch
     2025-09-16 21:24:55,428 TapTester - INFO     2025-09-16 21:24:55,428Z target - INFO projects (73): Batch is valid
     2025-09-16 21:24:55,428 TapTester - INFO     2025-09-16 21:24:55,428Z target - INFO Requests complete, stopping loop
     2025-09-16 21:24:55,491 TapTester - INFO     2025-09-16 21:24:55,491Z   main - INFO Target exited normally with status 0
     2025-09-16 21:24:55,492 TapTester - INFO     2025-09-16 21:24:55,491Z   main - WARNING Not publishing metrics because some environment variables are not configured
     2025-09-16 21:24:55,492 TapTester - INFO     2025-09-16 21:24:55,492Z   main - INFO No tunnel subprocess to tear down
     2025-09-16 21:24:55,492 TapTester - INFO     2025-09-16 21:24:55,492Z   main - INFO Exit status is: Discovery succeeded. Tap failed with code 1 and error message: "Payment Required: Portfolios are only available for users in an Enterprise or Business plan.". Target succeeded.
     2025-09-16 21:25:00,623 TapTester - INFO     **************************************************************************************************************
     2025-09-16 21:25:00,623 TapTester - INFO     sync mode exited succesfully
     2025-09-16 21:25:00,630 TapTester - ERROR
     ======================================================================
     FAIL: test_run (test_all_fields.AsanaAllFieldsTest.test_run)
     Testing that all fields mentioned in the catalog are synced from the tap
     ----------------------------------------------------------------------
     Traceback (most recent call last):
       File "/opt/code/tap-asana/tests/test_all_fields.py", line 70, in test_run
         record_count_by_stream = self.run_and_verify_sync(conn_id)
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       File "/opt/code/tap-asana/tests/base.py", line 214, in run_and_verify_sync
         menagerie.verify_sync_exit_status(self, exit_status, sync_job_name)
       File "/opt/code/tap-tester/tap_tester/menagerie.py", line 100, in verify_sync_exit_status
         test_case.assertEqual(
     AssertionError: 1 != 0 : tap_exit_status for job(3-168-1758057891) was NOT 0. {'target_exit_status': 0, 'tap_error_message': 'Payment Required: Portfolios are only available for users in an Enterprise or Business plan.', 'check_exit_status': None, 'name': '3-168-1758057891', 'start_time': None, 'mode': 'sync', 'tap_exit_status': 1, 'target_error_message': None, 'discovery_exit_status': 0, 'completion_time': '2025-09-16T21:24:55Z', 'error': True, 'discovery_error_message': None}

     2025-09-16 21:25:00,630 TapTester - INFO     ***** Test Results *****
     ----------------------------------------------------------------------
     Ran 1 tests in 19s

     FAILED  (failures=1)


</details>