### PR TITLE
Update for excluding unauth streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
-## 2.5.2
-  * Streams that the credentials cannot access (402/403) are now excluded from the catalog during discovery instead of raising an error. A warning is logged for each excluded stream. [#73](https://github.com/singer-io/tap-asana/pull/73)
+## 2.6.0
+  * Exclude inaccessible streams (402/403) from the catalog during discovery instead of raising an error. [#73](https://github.com/singer-io/tap-asana/pull/73)
 
 ## 2.5.1
   * Added a try/except asana.rest.ApiException block inside the wrapper function of asana_error_handling in base.py. Fix for api exception. [#72](https://github.com/singer-io/tap-asana/pull/72)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 2.5.2
-  * Streams the credentials cannot access (402/403) are now excluded from the catalog during discovery instead of raising an error. A warning is logged for each excluded stream. [#73](https://github.com/singer-io/tap-asana/pull/73)
+  * Streams that the credentials cannot access (402/403) are now excluded from the catalog during discovery instead of raising an error. A warning is logged for each excluded stream. [#73](https://github.com/singer-io/tap-asana/pull/73)
 
 ## 2.5.1
   * Added a try/except asana.rest.ApiException block inside the wrapper function of asana_error_handling in base.py. Fix for api exception. [#72](https://github.com/singer-io/tap-asana/pull/72)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.5.2
+  * Streams the credentials cannot access (402/403) are now excluded from the catalog during discovery instead of raising an error. A warning is logged for each excluded stream. [#73](https://github.com/singer-io/tap-asana/pull/73)
+
 ## 2.5.1
   * Added a try/except asana.rest.ApiException block inside the wrapper function of asana_error_handling in base.py. Fix for api exception. [#72](https://github.com/singer-io/tap-asana/pull/72)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-asana",
-    version="2.5.1",
+    version="2.5.2",
     description="Singer.io tap for extracting Asana data",
     author="Stitch",
     url="http://github.com/singer-io/tap-asana",

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-asana",
-    version="2.5.2",
+    version="2.6.0",
     description="Singer.io tap for extracting Asana data",
     author="Stitch",
     url="http://github.com/singer-io/tap-asana",

--- a/tap_asana/__init__.py
+++ b/tap_asana/__init__.py
@@ -8,6 +8,7 @@ from singer import metadata
 from singer import Transformer
 from tap_asana.asana import Asana
 from tap_asana.context import Context
+import tap_asana.streams  # Load stream objects into Context
 
 _AsanaApiException = sys.modules["asana.rest"].ApiException
 

--- a/tap_asana/__init__.py
+++ b/tap_asana/__init__.py
@@ -1,16 +1,16 @@
 #!/usr/bin/env python3
 import os
 import json
-import sys
+import asana.rest
 import singer
 from singer import utils
 from singer import metadata
 from singer import Transformer
+# Import directly before 'from tap_asana.asana import Asana' shadows the 'asana' name in globals
+from asana.rest import ApiException as _AsanaApiException
 from tap_asana.asana import Asana
 from tap_asana.context import Context
 import tap_asana.streams  # Load stream objects into Context
-
-_AsanaApiException = sys.modules["asana.rest"].ApiException
 
 REQUIRED_CONFIG_KEYS = [
     "start_date",
@@ -83,7 +83,7 @@ def discover():
 
     # Probe workspace access once — this is the common gate for all streams.
     workspaces = None
-    if hasattr(Context.asana, "client"):
+    if getattr(Context.asana, "client", None):
         try:
             workspaces = Context.stream_objects["workspaces"]().fetch_workspaces()
         except _AsanaApiException as e:
@@ -113,7 +113,7 @@ def discover():
                         "Stream '%s' is not accessible (HTTP %s), excluding from catalog.",
                         schema_name, e.status,
                     )
-                    error_list.append(schema_name)
+                    error_list.append((schema_name, e.status))
                     continue
                 raise
 
@@ -130,16 +130,18 @@ def discover():
         streams.append(catalog_entry)
 
     if error_list:
+        excluded_streams = ", ".join(name for name, _ in error_list)
+        status_codes = "/".join(str(s) for s in sorted({status for _, status in error_list}))
         if not streams:
             raise RuntimeError(
-                "HTTP-error-code: 403, Error: The account credentials supplied do not have "
+                f"HTTP-error-code: {status_codes}, Error: The account credentials supplied do not have "
                 "'read' access to any of the streams supported by the tap. "
                 "Data collection cannot be initiated due to lack of permissions."
             )
         LOGGER.warning(
             "The account credentials supplied do not have 'read' access to the following "
             "stream(s): %s. These streams have been excluded from the catalog.",
-            ", ".join(error_list),
+            excluded_streams,
         )
 
     LOGGER.info("Finished discover")

--- a/tap_asana/__init__.py
+++ b/tap_asana/__init__.py
@@ -94,8 +94,8 @@ def _handle_excluded_streams(inaccessible_streams, streams):
 
     Mutates nothing — callers are responsible for the streams list.
     """
-    excluded_streams = ", ".join(name for name in inaccessible_streams)
-    status_codes = "/".join(str(s) for s in sorted({status for _, status in inaccessible_streams}))
+    excluded_streams = ", ".join(name for name, _ in inaccessible_streams)
+    status_codes = "/".join(str(s) for s in sorted({status for _, status in inaccessible_streams if status is not None}))
     if not streams:
         raise RuntimeError(
             f"HTTP-error-code: {status_codes}, Error: The account credentials supplied do not have "
@@ -134,7 +134,7 @@ def discover():
                 "Stream '%s' is not accessible, excluding from catalog.",
                 schema_name,
             )
-            inaccessible_streams.append(schema_name)
+            inaccessible_streams.append((schema_name, None))
             continue
 
         streams.append({

--- a/tap_asana/__init__.py
+++ b/tap_asana/__init__.py
@@ -75,13 +75,8 @@ def get_discovery_metadata(stream, schema):
 
 def _probe_workspaces():
     """Fetch the list of workspaces from the Asana API.
-
-    Returns the workspace list, or None when no authenticated client is
-    available (e.g. during unit tests). Raises RuntimeError immediately
-    when the credentials have no access at all (HTTP 402/403).
+    Raises RuntimeError when the credentials have no access (HTTP 402/403).
     """
-    if not getattr(Context.asana, "client", None):
-        return None
     try:
         return Context.stream_objects["workspaces"]().fetch_workspaces()
     except _AsanaApiException as e:
@@ -94,48 +89,11 @@ def _probe_workspaces():
         raise
 
 
-def _check_stream_access(schema_name, stream, workspaces):
-    """Probe stream-specific access when required (e.g. Portfolios / HTTP 402).
-
-    Returns True when the stream is accessible or does not require a check.
-    Returns False and logs a warning when the stream is inaccessible (HTTP 402/403).
-    Re-raises for any other API error.
-    """
-    if workspaces is None or not stream.requires_access_check:
-        return True
-    try:
-        stream.check_access(workspaces)
-        return True
-    except _AsanaApiException as e:
-        if e.status in [402, 403]:
-            LOGGER.warning(
-                "Stream '%s' is not accessible (HTTP %s), excluding from catalog.",
-                schema_name, e.status,
-            )
-            return False
-        raise
-
-
-def _build_catalog_entry(schema_name, schema, stream):
-    """Build a single Singer catalog entry dict from schema and stream metadata."""
-    return {
-        "stream": schema_name,
-        "tap_stream_id": schema_name,
-        "schema": singer.resolve_schema_references(schema, {}),
-        "metadata": get_discovery_metadata(stream, schema),
-        "key_properties": stream.key_properties,
-        "replication_key": stream.replication_key,
-        "replication_method": stream.replication_method,
-    }
-
-
 def _handle_excluded_streams(error_list, streams):
     """Raise RuntimeError when no streams are accessible; otherwise warn.
 
     Mutates nothing — callers are responsible for the streams list.
     """
-    if not error_list:
-        return
     excluded_streams = ", ".join(name for name, _ in error_list)
     status_codes = "/".join(str(s) for s in sorted({status for _, status in error_list}))
     if not streams:
@@ -171,13 +129,26 @@ def discover():
 
         stream = Context.stream_objects[schema_name]()
 
-        if not _check_stream_access(schema_name, stream, workspaces):
+        if stream.check_access(workspaces) is False:
+            LOGGER.warning(
+                "Stream '%s' is not accessible, excluding from catalog.",
+                schema_name,
+            )
             error_list.append((schema_name, None))
             continue
 
-        streams.append(_build_catalog_entry(schema_name, schema, stream))
+        streams.append({
+            "stream": schema_name,
+            "tap_stream_id": schema_name,
+            "schema": singer.resolve_schema_references(schema, {}),
+            "metadata": get_discovery_metadata(stream, schema),
+            "key_properties": stream.key_properties,
+            "replication_key": stream.replication_key,
+            "replication_method": stream.replication_method,
+        })
 
-    _handle_excluded_streams(error_list, streams)
+    if error_list:
+        _handle_excluded_streams(error_list, streams)
     LOGGER.info("Finished discover")
     return {"streams": streams}
 
@@ -196,66 +167,47 @@ def shuffle_streams(stream_name):
     Context.catalog["streams"] = top_half + bottom_half
 
 
-def _emit_schemas():
-    """Write Singer schema messages for every selected stream in the catalog."""
+def sync():
+    """Sync logic for tap"""
+    # Emit all schemas first so we have them for child streams
     for stream in Context.catalog["streams"]:
         if Context.is_selected(stream["tap_stream_id"]):
-            singer.write_schema(
-                stream["tap_stream_id"],
-                stream["schema"],
-                stream["key_properties"],
-            )
+            singer.write_schema(stream["tap_stream_id"],
+                                stream["schema"],
+                                stream["key_properties"])
             Context.counts[stream["tap_stream_id"]] = 0
 
+    # Loop over streams in catalog
+    for catalog_entry in Context.catalog["streams"]:
+        stream_id = catalog_entry["tap_stream_id"]
+        stream = Context.stream_objects[stream_id]()
 
-def _sync_stream(catalog_entry):
-    """Sync a single stream: transform each record, write it, and update state."""
-    stream_id = catalog_entry["tap_stream_id"]
-    stream = Context.stream_objects[stream_id]()
+        if not Context.is_selected(stream_id):
+            LOGGER.info("Skipping stream: %s", stream_id)
+            continue
 
-    LOGGER.info("Syncing stream: %s", stream_id)
+        LOGGER.info("Syncing stream: %s", stream_id)
 
-    if not Context.state.get("bookmarks"):
-        Context.state["bookmarks"] = {}
-    Context.state["bookmarks"]["currently_sync_stream"] = stream_id
+        if not Context.state.get('bookmarks'):
+            Context.state['bookmarks'] = {}
+        Context.state['bookmarks']['currently_sync_stream'] = stream_id
 
-    with Transformer() as transformer:
-        for rec in stream.sync():
-            extraction_time = singer.utils.now()
-            record_schema = catalog_entry["schema"]
-            record_metadata = metadata.to_map(catalog_entry["metadata"])
-            rec = transformer.transform(rec, record_schema, record_metadata)
-            singer.write_record(stream_id, rec, time_extracted=extraction_time)
-            Context.counts[stream_id] += 1
+        with Transformer() as transformer:
+            for rec in stream.sync():
+                extraction_time = singer.utils.now()
+                record_schema = catalog_entry["schema"]
+                record_metadata = metadata.to_map(catalog_entry["metadata"])
+                rec = transformer.transform(rec, record_schema, record_metadata)
+                singer.write_record(stream_id, rec, time_extracted=extraction_time)
+                Context.counts[stream_id] += 1
 
-    Context.state["bookmarks"].pop("currently_sync_stream")
-    singer.write_state(Context.state)
+        Context.state["bookmarks"].pop("currently_sync_stream")
+        singer.write_state(Context.state)
 
-
-def _log_sync_counts():
-    """Log the number of records synced per stream."""
     LOGGER.info("----------------------")
     for stream_id, stream_count in Context.counts.items():
         LOGGER.info("%s: %d", stream_id, stream_count)
     LOGGER.info("----------------------")
-
-
-def sync():
-    """Sync all selected streams in the catalog.
-
-    Emits schemas first so child streams receive their parent schema,
-    then iterates over the catalog and syncs each selected stream.
-    """
-    _emit_schemas()
-
-    for catalog_entry in Context.catalog["streams"]:
-        stream_id = catalog_entry["tap_stream_id"]
-        if not Context.is_selected(stream_id):
-            LOGGER.info("Skipping stream: %s", stream_id)
-            continue
-        _sync_stream(catalog_entry)
-
-    _log_sync_counts()
 
 
 @utils.handle_top_exception(LOGGER)

--- a/tap_asana/__init__.py
+++ b/tap_asana/__init__.py
@@ -1,18 +1,15 @@
 #!/usr/bin/env python3
 import os
-import datetime
 import json
-import time
-import math
-import functools
-import asana
+import sys
 import singer
 from singer import utils
 from singer import metadata
 from singer import Transformer
 from tap_asana.asana import Asana
 from tap_asana.context import Context
-import tap_asana.streams  # Load stream objects into Context
+
+_AsanaApiException = sys.modules["asana.rest"].ApiException
 
 REQUIRED_CONFIG_KEYS = [
     "start_date",
@@ -81,6 +78,21 @@ def discover():
     raw_schemas = load_schemas()
 
     streams = []
+    error_list = []
+
+    # Probe workspace access once — this is the common gate for all streams.
+    workspaces = None
+    if hasattr(Context.asana, "client"):
+        try:
+            workspaces = Context.stream_objects["workspaces"]().fetch_workspaces()
+        except _AsanaApiException as e:
+            if e.status in [402, 403]:
+                raise RuntimeError(
+                    f"HTTP-error-code: {e.status}, Error: The account credentials supplied do not have "
+                    "'read' access to any of the streams supported by the tap. "
+                    "Data collection cannot be initiated due to lack of permissions."
+                ) from e
+            raise
 
     refs = {}
     for schema_name, schema in raw_schemas.items():
@@ -88,6 +100,21 @@ def discover():
             continue
 
         stream = Context.stream_objects[schema_name]()
+
+        # Only probe streams that require a stream-specific access check
+        # (e.g., Portfolios which needs a premium workspace — HTTP 402).
+        if workspaces is not None and stream.requires_access_check:
+            try:
+                stream.check_access(workspaces)
+            except _AsanaApiException as e:
+                if e.status in [402, 403]:
+                    LOGGER.warning(
+                        "Stream '%s' is not accessible (HTTP %s), excluding from catalog.",
+                        schema_name, e.status,
+                    )
+                    error_list.append(schema_name)
+                    continue
+                raise
 
         # Create and add catalog entry
         catalog_entry = {
@@ -100,6 +127,19 @@ def discover():
             "replication_method": stream.replication_method,
         }
         streams.append(catalog_entry)
+
+    if error_list:
+        if not streams:
+            raise RuntimeError(
+                "HTTP-error-code: 403, Error: The account credentials supplied do not have "
+                "'read' access to any of the streams supported by the tap. "
+                "Data collection cannot be initiated due to lack of permissions."
+            )
+        LOGGER.warning(
+            "The account credentials supplied do not have 'read' access to the following "
+            "stream(s): %s. These streams have been excluded from the catalog.",
+            ", ".join(error_list),
+        )
 
     LOGGER.info("Finished discover")
 

--- a/tap_asana/__init__.py
+++ b/tap_asana/__init__.py
@@ -89,13 +89,13 @@ def _probe_workspaces():
         raise
 
 
-def _handle_excluded_streams(error_list, streams):
+def _handle_excluded_streams(inaccessible_streams, streams):
     """Raise RuntimeError when no streams are accessible; otherwise warn.
 
     Mutates nothing — callers are responsible for the streams list.
     """
-    excluded_streams = ", ".join(name for name, _ in error_list)
-    status_codes = "/".join(str(s) for s in sorted({status for _, status in error_list}))
+    excluded_streams = ", ".join(name for name in inaccessible_streams)
+    status_codes = "/".join(str(s) for s in sorted({status for _, status in inaccessible_streams}))
     if not streams:
         raise RuntimeError(
             f"HTTP-error-code: {status_codes}, Error: The account credentials supplied do not have "
@@ -121,7 +121,7 @@ def discover():
     workspaces = _probe_workspaces()
 
     streams = []
-    error_list = []
+    inaccessible_streams = []
 
     for schema_name, schema in raw_schemas.items():
         if schema_name not in Context.stream_objects:
@@ -134,7 +134,7 @@ def discover():
                 "Stream '%s' is not accessible, excluding from catalog.",
                 schema_name,
             )
-            error_list.append((schema_name, None))
+            inaccessible_streams.append(schema_name)
             continue
 
         streams.append({
@@ -147,8 +147,8 @@ def discover():
             "replication_method": stream.replication_method,
         })
 
-    if error_list:
-        _handle_excluded_streams(error_list, streams)
+    if inaccessible_streams:
+        _handle_excluded_streams(inaccessible_streams, streams)
     LOGGER.info("Finished discover")
     return {"streams": streams}
 

--- a/tap_asana/__init__.py
+++ b/tap_asana/__init__.py
@@ -73,79 +73,112 @@ def get_discovery_metadata(stream, schema):
     return metadata.to_list(mdata)
 
 
+def _probe_workspaces():
+    """Fetch the list of workspaces from the Asana API.
+
+    Returns the workspace list, or None when no authenticated client is
+    available (e.g. during unit tests). Raises RuntimeError immediately
+    when the credentials have no access at all (HTTP 402/403).
+    """
+    if not getattr(Context.asana, "client", None):
+        return None
+    try:
+        return Context.stream_objects["workspaces"]().fetch_workspaces()
+    except _AsanaApiException as e:
+        if e.status in [402, 403]:
+            raise RuntimeError(
+                f"HTTP-error-code: {e.status}, Error: The account credentials supplied do not have "
+                "'read' access to any of the streams supported by the tap. "
+                "Data collection cannot be initiated due to lack of permissions."
+            ) from e
+        raise
+
+
+def _check_stream_access(schema_name, stream, workspaces):
+    """Probe stream-specific access when required (e.g. Portfolios / HTTP 402).
+
+    Returns True when the stream is accessible or does not require a check.
+    Returns False and logs a warning when the stream is inaccessible (HTTP 402/403).
+    Re-raises for any other API error.
+    """
+    if workspaces is None or not stream.requires_access_check:
+        return True
+    try:
+        stream.check_access(workspaces)
+        return True
+    except _AsanaApiException as e:
+        if e.status in [402, 403]:
+            LOGGER.warning(
+                "Stream '%s' is not accessible (HTTP %s), excluding from catalog.",
+                schema_name, e.status,
+            )
+            return False
+        raise
+
+
+def _build_catalog_entry(schema_name, schema, stream):
+    """Build a single Singer catalog entry dict from schema and stream metadata."""
+    return {
+        "stream": schema_name,
+        "tap_stream_id": schema_name,
+        "schema": singer.resolve_schema_references(schema, {}),
+        "metadata": get_discovery_metadata(stream, schema),
+        "key_properties": stream.key_properties,
+        "replication_key": stream.replication_key,
+        "replication_method": stream.replication_method,
+    }
+
+
+def _handle_excluded_streams(error_list, streams):
+    """Raise RuntimeError when no streams are accessible; otherwise warn.
+
+    Mutates nothing — callers are responsible for the streams list.
+    """
+    if not error_list:
+        return
+    excluded_streams = ", ".join(name for name, _ in error_list)
+    status_codes = "/".join(str(s) for s in sorted({status for _, status in error_list}))
+    if not streams:
+        raise RuntimeError(
+            f"HTTP-error-code: {status_codes}, Error: The account credentials supplied do not have "
+            "'read' access to any of the streams supported by the tap. "
+            "Data collection cannot be initiated due to lack of permissions."
+        )
+    LOGGER.warning(
+        "The account credentials supplied do not have 'read' access to the following "
+        "stream(s): %s. These streams have been excluded from the catalog.",
+        excluded_streams,
+    )
+
+
 def discover():
-    """Discover logic for tap"""
+    """Build and return the Singer catalog.
+
+    Probes workspace and per-stream access when a client is present;
+    streams that are inaccessible (HTTP 402/403) are excluded from the
+    catalog and a warning is logged for each.
+    """
     LOGGER.info("Starting discover")
     raw_schemas = load_schemas()
+    workspaces = _probe_workspaces()
 
     streams = []
     error_list = []
 
-    # Probe workspace access once — this is the common gate for all streams.
-    workspaces = None
-    if getattr(Context.asana, "client", None):
-        try:
-            workspaces = Context.stream_objects["workspaces"]().fetch_workspaces()
-        except _AsanaApiException as e:
-            if e.status in [402, 403]:
-                raise RuntimeError(
-                    f"HTTP-error-code: {e.status}, Error: The account credentials supplied do not have "
-                    "'read' access to any of the streams supported by the tap. "
-                    "Data collection cannot be initiated due to lack of permissions."
-                ) from e
-            raise
-
-    refs = {}
     for schema_name, schema in raw_schemas.items():
         if schema_name not in Context.stream_objects:
             continue
 
         stream = Context.stream_objects[schema_name]()
 
-        # Only probe streams that require a stream-specific access check
-        # (e.g., Portfolios which needs a premium workspace — HTTP 402).
-        if workspaces is not None and stream.requires_access_check:
-            try:
-                stream.check_access(workspaces)
-            except _AsanaApiException as e:
-                if e.status in [402, 403]:
-                    LOGGER.warning(
-                        "Stream '%s' is not accessible (HTTP %s), excluding from catalog.",
-                        schema_name, e.status,
-                    )
-                    error_list.append((schema_name, e.status))
-                    continue
-                raise
+        if not _check_stream_access(schema_name, stream, workspaces):
+            error_list.append((schema_name, None))
+            continue
 
-        # Create and add catalog entry
-        catalog_entry = {
-            "stream": schema_name,
-            "tap_stream_id": schema_name,
-            "schema": singer.resolve_schema_references(schema, refs),
-            "metadata": get_discovery_metadata(stream, schema),
-            "key_properties": stream.key_properties,
-            "replication_key": stream.replication_key,
-            "replication_method": stream.replication_method,
-        }
-        streams.append(catalog_entry)
+        streams.append(_build_catalog_entry(schema_name, schema, stream))
 
-    if error_list:
-        excluded_streams = ", ".join(name for name, _ in error_list)
-        status_codes = "/".join(str(s) for s in sorted({status for _, status in error_list}))
-        if not streams:
-            raise RuntimeError(
-                f"HTTP-error-code: {status_codes}, Error: The account credentials supplied do not have "
-                "'read' access to any of the streams supported by the tap. "
-                "Data collection cannot be initiated due to lack of permissions."
-            )
-        LOGGER.warning(
-            "The account credentials supplied do not have 'read' access to the following "
-            "stream(s): %s. These streams have been excluded from the catalog.",
-            excluded_streams,
-        )
-
+    _handle_excluded_streams(error_list, streams)
     LOGGER.info("Finished discover")
-
     return {"streams": streams}
 
 
@@ -163,47 +196,66 @@ def shuffle_streams(stream_name):
     Context.catalog["streams"] = top_half + bottom_half
 
 
-def sync():
-    """Sync logic for tap"""
-    # Emit all schemas first so we have them for child streams
+def _emit_schemas():
+    """Write Singer schema messages for every selected stream in the catalog."""
     for stream in Context.catalog["streams"]:
         if Context.is_selected(stream["tap_stream_id"]):
-            singer.write_schema(stream["tap_stream_id"],
-                                stream["schema"],
-                                stream["key_properties"])
+            singer.write_schema(
+                stream["tap_stream_id"],
+                stream["schema"],
+                stream["key_properties"],
+            )
             Context.counts[stream["tap_stream_id"]] = 0
 
-    # Loop over streams in catalog
-    for catalog_entry in Context.catalog["streams"]:
-        stream_id = catalog_entry["tap_stream_id"]
-        stream = Context.stream_objects[stream_id]()
 
-        if not Context.is_selected(stream_id):
-            LOGGER.info("Skipping stream: %s", stream_id)
-            continue
+def _sync_stream(catalog_entry):
+    """Sync a single stream: transform each record, write it, and update state."""
+    stream_id = catalog_entry["tap_stream_id"]
+    stream = Context.stream_objects[stream_id]()
 
-        LOGGER.info("Syncing stream: %s", stream_id)
+    LOGGER.info("Syncing stream: %s", stream_id)
 
-        if not Context.state.get('bookmarks'):
-            Context.state['bookmarks'] = {}
-        Context.state['bookmarks']['currently_sync_stream'] = stream_id
+    if not Context.state.get("bookmarks"):
+        Context.state["bookmarks"] = {}
+    Context.state["bookmarks"]["currently_sync_stream"] = stream_id
 
-        with Transformer() as transformer:
-            for rec in stream.sync():
-                extraction_time = singer.utils.now()
-                record_schema = catalog_entry["schema"]
-                record_metadata = metadata.to_map(catalog_entry["metadata"])
-                rec = transformer.transform(rec, record_schema, record_metadata)
-                singer.write_record(stream_id, rec, time_extracted=extraction_time)
-                Context.counts[stream_id] += 1
+    with Transformer() as transformer:
+        for rec in stream.sync():
+            extraction_time = singer.utils.now()
+            record_schema = catalog_entry["schema"]
+            record_metadata = metadata.to_map(catalog_entry["metadata"])
+            rec = transformer.transform(rec, record_schema, record_metadata)
+            singer.write_record(stream_id, rec, time_extracted=extraction_time)
+            Context.counts[stream_id] += 1
 
-        Context.state["bookmarks"].pop("currently_sync_stream")
-        singer.write_state(Context.state)
+    Context.state["bookmarks"].pop("currently_sync_stream")
+    singer.write_state(Context.state)
 
+
+def _log_sync_counts():
+    """Log the number of records synced per stream."""
     LOGGER.info("----------------------")
     for stream_id, stream_count in Context.counts.items():
         LOGGER.info("%s: %d", stream_id, stream_count)
     LOGGER.info("----------------------")
+
+
+def sync():
+    """Sync all selected streams in the catalog.
+
+    Emits schemas first so child streams receive their parent schema,
+    then iterates over the catalog and syncs each selected stream.
+    """
+    _emit_schemas()
+
+    for catalog_entry in Context.catalog["streams"]:
+        stream_id = catalog_entry["tap_stream_id"]
+        if not Context.is_selected(stream_id):
+            LOGGER.info("Skipping stream: %s", stream_id)
+            continue
+        _sync_stream(catalog_entry)
+
+    _log_sync_counts()
 
 
 @utils.handle_top_exception(LOGGER)

--- a/tap_asana/streams/base.py
+++ b/tap_asana/streams/base.py
@@ -139,9 +139,6 @@ class Stream():
     replication_method = None
     replication_key = None
     key_properties = ["gid"]
-    # Set to True in subclasses that need a stream-specific access probe
-    # beyond the common workspace check performed once in discover().
-    requires_access_check = False
     # Controls which SDK object we use to call the API by default.
 
     def __init__(self):
@@ -250,7 +247,8 @@ class Stream():
 
     def check_access(self, workspaces):
         """Stream-specific access probe. Override in subclasses that require
-        an endpoint check beyond the common workspace check in discover()."""
+        an endpoint check beyond the common workspace check in discover().
+        Return False to exclude the stream from the catalog; None (default) means no check."""
 
     @asana_error_handling
     def fetch_workspaces(self, opts=None):

--- a/tap_asana/streams/base.py
+++ b/tap_asana/streams/base.py
@@ -139,6 +139,9 @@ class Stream():
     replication_method = None
     replication_key = None
     key_properties = ["gid"]
+    # Set to True in subclasses that need a stream-specific access probe
+    # beyond the common workspace check performed once in discover().
+    requires_access_check = False
     # Controls which SDK object we use to call the API by default.
 
     def __init__(self):
@@ -235,8 +238,7 @@ class Stream():
                 raise InvalidTokenError(response=e) from e
             if e.status == 401:
                 raise NoAuthorizationError(response=e) from e
-            LOGGER.error("Error during API call: %s", e)
-            raise e from None
+            raise
 
         return results
 
@@ -245,6 +247,10 @@ class Stream():
         """Yield's processed SDK object dicts to the caller."""
         for obj in self.get_objects():
             yield obj
+
+    def check_access(self, workspaces):
+        """Stream-specific access probe. Override in subclasses that require
+        an endpoint check beyond the common workspace check in discover()."""
 
     @asana_error_handling
     def fetch_workspaces(self, opts=None):

--- a/tap_asana/streams/base.py
+++ b/tap_asana/streams/base.py
@@ -248,7 +248,8 @@ class Stream():
     def check_access(self, workspaces):
         """Stream-specific access probe. Override in subclasses that require
         an endpoint check beyond the common workspace check in discover().
-        Return False to exclude the stream from the catalog; None (default) means no check."""
+        Return False to exclude the stream from the catalog; True (default) means accessible."""
+        return True
 
     @asana_error_handling
     def fetch_workspaces(self, opts=None):

--- a/tap_asana/streams/portfolios.py
+++ b/tap_asana/streams/portfolios.py
@@ -6,6 +6,7 @@ from tap_asana.streams.base import Stream
 class Portfolios(Stream):
     name = "portfolios"
     replication_method = "FULL_TABLE"
+    requires_access_check = True
 
     fields = [
         "gid",
@@ -27,6 +28,22 @@ class Portfolios(Stream):
         "custom_fields",
         "public"
     ]
+
+    def check_access(self, workspaces):
+        """
+        Verify access to the portfolios endpoint.
+        Portfolios require a premium/business workspace (HTTP 402 if not eligible).
+        Probes the portfolios API with the first available workspace.
+        """
+        if workspaces:
+            portfolios_api = asana.PortfoliosApi(Context.asana.client)
+            self.call_api(
+                portfolios_api,
+                "get_portfolios",
+                workspace=workspaces[0]["gid"],
+                opts={"owner": "me"},
+                _request_timeout=self.request_timeout,
+            )
 
     def get_objects(self):
         """Get stream object"""

--- a/tap_asana/streams/portfolios.py
+++ b/tap_asana/streams/portfolios.py
@@ -6,7 +6,6 @@ from tap_asana.streams.base import Stream
 class Portfolios(Stream):
     name = "portfolios"
     replication_method = "FULL_TABLE"
-    requires_access_check = True
 
     fields = [
         "gid",
@@ -33,9 +32,11 @@ class Portfolios(Stream):
         """
         Verify access to the portfolios endpoint.
         Portfolios require a premium/business workspace (HTTP 402 if not eligible).
-        Probes the portfolios API with the first available workspace.
+        Returns True when accessible, False when the workspace does not support portfolios.
         """
-        if workspaces:
+        if not workspaces:
+            return True
+        try:
             portfolios_api = asana.PortfoliosApi(Context.asana.client)
             self.call_api(
                 portfolios_api,
@@ -44,6 +45,11 @@ class Portfolios(Stream):
                 opts={"owner": "me", "limit": 1},
                 _request_timeout=self.request_timeout,
             )
+            return True
+        except asana.rest.ApiException as e:
+            if e.status in [402, 403]:
+                return False
+            raise
 
     def get_objects(self):
         """Get stream object"""

--- a/tap_asana/streams/portfolios.py
+++ b/tap_asana/streams/portfolios.py
@@ -41,7 +41,7 @@ class Portfolios(Stream):
                 portfolios_api,
                 "get_portfolios",
                 workspace=workspaces[0]["gid"],
-                opts={"owner": "me"},
+                opts={"owner": "me", "limit": 1},
                 _request_timeout=self.request_timeout,
             )
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -71,11 +71,6 @@ class AsanaBase(unittest.TestCase):
         Provides the expected metadata for each stream.
         """
         return {
-            "portfolios": {
-                self.PRIMARY_KEYS: {"gid"},
-                self.REPLICATION_METHOD: self.FULL_TABLE,
-                self.OBEYS_START_DATE: False
-            },
             "projects": {
                 self.PRIMARY_KEYS: {"gid"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,

--- a/tests/unittests/test_discover.py
+++ b/tests/unittests/test_discover.py
@@ -1,0 +1,237 @@
+"""Unit tests for the refactored discover-mode helpers in tap_asana/__init__.py."""
+
+import unittest
+from unittest import mock
+
+import asana
+
+from tap_asana.asana import Asana
+from tap_asana.context import Context
+from tap_asana.streams.portfolios import Portfolios
+import tap_asana
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_api_exception(status):
+    """Return an asana.rest.ApiException with the given HTTP status."""
+    exc = asana.rest.ApiException(status=status, reason="test")
+    exc.status = status
+    return exc
+
+
+# ---------------------------------------------------------------------------
+# _probe_workspaces
+# ---------------------------------------------------------------------------
+
+class TestProbeWorkspaces(unittest.TestCase):
+
+    @mock.patch("tap_asana.asana.Asana.refresh_access_token")
+    def setUp(self, _):
+        Context.config = {"start_date": "2020-01-01T00:00:00Z"}
+        Context.asana = Asana("test", "test", "test", "test", "test")
+
+    def tearDown(self):
+        if hasattr(Context, "asana") and hasattr(Context.asana, "client") and Context.asana.client:
+            try:
+                Context.asana.client.pool.close()
+                Context.asana.client.pool.join()
+            except Exception:
+                pass
+
+    @mock.patch("tap_asana.streams.base.Stream.fetch_workspaces")
+    def test_returns_workspace_list(self, mocked_fetch):
+        """_probe_workspaces() should return the list returned by fetch_workspaces."""
+        mocked_fetch.return_value = [{"gid": "ws1"}]
+        result = tap_asana._probe_workspaces()
+        self.assertEqual(result, [{"gid": "ws1"}])
+
+    @mock.patch("tap_asana.streams.base.Stream.fetch_workspaces")
+    def test_raises_runtime_error_on_402(self, mocked_fetch):
+        """_probe_workspaces() should raise RuntimeError containing the HTTP status when 402 is returned."""
+        mocked_fetch.side_effect = _make_api_exception(402)
+        with self.assertRaises(RuntimeError) as ctx:
+            tap_asana._probe_workspaces()
+        self.assertIn("HTTP-error-code: 402", str(ctx.exception))
+
+    @mock.patch("tap_asana.streams.base.Stream.fetch_workspaces")
+    def test_raises_runtime_error_on_403(self, mocked_fetch):
+        """_probe_workspaces() should raise RuntimeError containing the HTTP status when 403 is returned."""
+        mocked_fetch.side_effect = _make_api_exception(403)
+        with self.assertRaises(RuntimeError) as ctx:
+            tap_asana._probe_workspaces()
+        self.assertIn("HTTP-error-code: 403", str(ctx.exception))
+
+    @mock.patch("tap_asana.streams.base.Stream.fetch_workspaces")
+    def test_re_raises_other_api_errors(self, mocked_fetch):
+        """_probe_workspaces() should re-raise ApiException for status codes other than 402/403 (e.g. 500)."""
+        mocked_fetch.side_effect = _make_api_exception(500)
+        with self.assertRaises(asana.rest.ApiException):
+            tap_asana._probe_workspaces()
+
+
+# ---------------------------------------------------------------------------
+# _handle_excluded_streams
+# ---------------------------------------------------------------------------
+
+class TestHandleExcludedStreams(unittest.TestCase):
+
+    def test_raises_when_no_accessible_streams_remain(self):
+        """_handle_excluded_streams() should raise RuntimeError when the streams list is empty (all excluded)."""
+        error_list = [("portfolios", None)]
+        with self.assertRaises(RuntimeError) as ctx:
+            tap_asana._handle_excluded_streams(error_list, streams=[])
+        self.assertIn("lack of permissions", str(ctx.exception))
+
+    def test_warns_when_some_streams_still_accessible(self):
+        """_handle_excluded_streams() should log a warning naming the excluded streams when others remain accessible."""
+        error_list = [("portfolios", None)]
+        remaining = [{"stream": "tasks"}]
+        with mock.patch.object(tap_asana.LOGGER, "warning") as mocked_warn:
+            tap_asana._handle_excluded_streams(error_list, remaining)
+        mocked_warn.assert_called_once()
+        self.assertIn("portfolios", mocked_warn.call_args[0][1])
+
+
+# ---------------------------------------------------------------------------
+# Portfolios.check_access
+# ---------------------------------------------------------------------------
+
+class TestPortfoliosCheckAccess(unittest.TestCase):
+
+    @mock.patch("tap_asana.asana.Asana.refresh_access_token")
+    def setUp(self, _):
+        Context.config = {"start_date": "2020-01-01T00:00:00Z"}
+        Context.asana = Asana("test", "test", "test", "test", "test")
+
+    def tearDown(self):
+        if hasattr(Context, "asana") and hasattr(Context.asana, "client") and Context.asana.client:
+            try:
+                Context.asana.client.pool.close()
+                Context.asana.client.pool.join()
+            except Exception:
+                pass
+
+    def test_returns_true_when_workspaces_empty(self):
+        """check_access() should return True without calling the API when the workspace list is empty."""
+        stream = Portfolios()
+        self.assertTrue(stream.check_access([]))
+
+    @mock.patch("asana.PortfoliosApi.get_portfolios")
+    def test_returns_true_when_api_succeeds(self, mocked_get):
+        """check_access() should return True when the portfolios API probe succeeds."""
+        mocked_get.return_value = iter([])
+        stream = Portfolios()
+        result = stream.check_access([{"gid": "ws1"}])
+        self.assertTrue(result)
+
+    @mock.patch("asana.PortfoliosApi.get_portfolios")
+    def test_returns_false_on_402(self, mocked_get):
+        """check_access() should return False when the API returns HTTP 402 (payment required / non-premium workspace)."""
+        mocked_get.side_effect = _make_api_exception(402)
+        stream = Portfolios()
+        result = stream.check_access([{"gid": "ws1"}])
+        self.assertFalse(result)
+
+    @mock.patch("asana.PortfoliosApi.get_portfolios")
+    def test_returns_false_on_403(self, mocked_get):
+        """check_access() should return False when the API returns HTTP 403 (forbidden)."""
+        mocked_get.side_effect = _make_api_exception(403)
+        stream = Portfolios()
+        result = stream.check_access([{"gid": "ws1"}])
+        self.assertFalse(result)
+
+    @mock.patch("asana.PortfoliosApi.get_portfolios")
+    def test_re_raises_unexpected_api_error(self, mocked_get):
+        """check_access() should re-raise ApiException for status codes other than 402/403."""
+        mocked_get.side_effect = _make_api_exception(500)
+        stream = Portfolios()
+        with self.assertRaises(asana.rest.ApiException):
+            stream.check_access([{"gid": "ws1"}])
+
+    @mock.patch("asana.PortfoliosApi.get_portfolios")
+    def test_probes_with_first_workspace_only(self, mocked_get):
+        """check_access() should only probe the first workspace in the list, not iterate all of them."""
+        mocked_get.return_value = iter([])
+        stream = Portfolios()
+        stream.check_access([{"gid": "ws1"}, {"gid": "ws2"}])
+        call_kwargs = mocked_get.call_args[1]
+        self.assertEqual(call_kwargs.get("workspace"), "ws1")
+
+
+# ---------------------------------------------------------------------------
+# discover() — stream exclusion behaviour
+# ---------------------------------------------------------------------------
+
+class TestDiscover(unittest.TestCase):
+
+    @mock.patch("tap_asana.asana.Asana.refresh_access_token")
+    def setUp(self, _):
+        Context.config = {"start_date": "2020-01-01T00:00:00Z"}
+        Context.state = {}
+        Context.asana = Asana("test", "test", "test", "test", "test")
+
+    def tearDown(self):
+        if hasattr(Context, "asana") and hasattr(Context.asana, "client") and Context.asana.client:
+            try:
+                Context.asana.client.pool.close()
+                Context.asana.client.pool.join()
+            except Exception:
+                pass
+
+    @mock.patch("tap_asana._probe_workspaces", return_value=[{"gid": "ws1"}])
+    @mock.patch("tap_asana.load_schemas", return_value={
+        "tasks": {"properties": {"gid": {"type": "string"}}},
+    })
+    def test_accessible_stream_included_in_catalog(self, _schemas, _ws):
+        """discover() should include streams whose check_access() returns True (default) in the catalog."""
+        catalog = tap_asana.discover()
+        stream_ids = [s["tap_stream_id"] for s in catalog["streams"]]
+        self.assertIn("tasks", stream_ids)
+
+    @mock.patch("tap_asana._probe_workspaces", return_value=[{"gid": "ws1"}])
+    @mock.patch("tap_asana.load_schemas", return_value={
+        "portfolios": {"properties": {"gid": {"type": "string"}}},
+        "tasks": {"properties": {"gid": {"type": "string"}}},
+    })
+    @mock.patch("tap_asana.streams.portfolios.Portfolios.check_access", return_value=False)
+    def test_inaccessible_stream_excluded_from_catalog(self, _chk, _schemas, _ws):
+        """discover() should omit streams whose check_access() returns False and keep remaining ones."""
+        catalog = tap_asana.discover()
+        stream_ids = [s["tap_stream_id"] for s in catalog["streams"]]
+        self.assertNotIn("portfolios", stream_ids)
+        self.assertIn("tasks", stream_ids)
+
+    @mock.patch("tap_asana._probe_workspaces", return_value=[{"gid": "ws1"}])
+    @mock.patch("tap_asana.load_schemas", return_value={
+        "portfolios": {"properties": {"gid": {"type": "string"}}},
+    })
+    @mock.patch("tap_asana.streams.portfolios.Portfolios.check_access", return_value=False)
+    def test_raises_when_all_streams_inaccessible(self, _chk, _schemas, _ws):
+        """discover() should raise RuntimeError when every stream is excluded by check_access()."""
+        with self.assertRaises(RuntimeError) as ctx:
+            tap_asana.discover()
+        self.assertIn("lack of permissions", str(ctx.exception))
+
+    @mock.patch("tap_asana._probe_workspaces", return_value=[{"gid": "ws1"}])
+    @mock.patch("tap_asana.load_schemas", return_value={
+        "tasks": {"properties": {"gid": {"type": "string"}}},
+    })
+    def test_catalog_entry_has_required_keys(self, _schemas, _ws):
+        """Each catalog entry produced by discover() must contain stream, tap_stream_id, schema, metadata, and key_properties."""
+        catalog = tap_asana.discover()
+        entry = catalog["streams"][0]
+        for key in ("stream", "tap_stream_id", "schema", "metadata", "key_properties"):
+            self.assertIn(key, entry)
+
+    @mock.patch("tap_asana._probe_workspaces", return_value=[{"gid": "ws1"}])
+    @mock.patch("tap_asana.load_schemas", return_value={
+        "tasks": {"properties": {"gid": {"type": "string"}}},
+    })
+    def test_schema_name_not_in_stream_objects_is_skipped(self, _schemas, _ws):
+        """Schemas without a matching stream object are silently skipped."""
+        with mock.patch.dict(Context.stream_objects, {}, clear=True):
+            catalog = tap_asana.discover()
+        self.assertEqual(catalog["streams"], [])

--- a/tests/unittests/test_discover.py
+++ b/tests/unittests/test_discover.py
@@ -80,17 +80,17 @@ class TestHandleExcludedStreams(unittest.TestCase):
 
     def test_raises_when_no_accessible_streams_remain(self):
         """_handle_excluded_streams() should raise RuntimeError when the streams list is empty (all excluded)."""
-        error_list = [("portfolios", None)]
+        inaccessible_streams = [("portfolios", None)]
         with self.assertRaises(RuntimeError) as ctx:
-            tap_asana._handle_excluded_streams(error_list, streams=[])
+            tap_asana._handle_excluded_streams(inaccessible_streams, streams=[])
         self.assertIn("lack of permissions", str(ctx.exception))
 
     def test_warns_when_some_streams_still_accessible(self):
         """_handle_excluded_streams() should log a warning naming the excluded streams when others remain accessible."""
-        error_list = [("portfolios", None)]
+        inaccessible_streams = [("portfolios", None)]
         remaining = [{"stream": "tasks"}]
         with mock.patch.object(tap_asana.LOGGER, "warning") as mocked_warn:
-            tap_asana._handle_excluded_streams(error_list, remaining)
+            tap_asana._handle_excluded_streams(inaccessible_streams, remaining)
         mocked_warn.assert_called_once()
         self.assertIn("portfolios", mocked_warn.call_args[0][1])
 


### PR DESCRIPTION
# Description of change
PR include implementation during discovery, streams returning HTTP 402/403 (e.g. portfolios requiring a premium Asana plan) are now silently excluded from the catalog with a WARNING instead of aborting the entire discovery. If no streams are accessible at all, a [RuntimeError] is raised.

# Manual QA steps
- [x]  Discovery: Running
- [x]  Sync: Running
- [x]  Unit Tests: Running
- [x]  Integration test: Running
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
