### PR TITLE
Move parameterized from install_requires to extras_require[test]

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,12 +11,12 @@ setup(
     py_modules=["tap_asana"],
     install_requires=[
         "asana==5.2.4",
-        "parameterized",
         "requests==2.33.1",
         "singer-python==6.8.0"
     ],
     extras_require={
         "test": [
+            "parameterized",
             "pylint"
         ],
         "dev": [


### PR DESCRIPTION
## Summary

`parameterized` is only used in test files (`tests/unittests/test_request_timeout.py`) and should not be included in the production image.

This moves it to `extras_require[test]` so it is still installed via `pip install .[test]` in CI but excluded from the final deployed artifact.